### PR TITLE
feat: Support ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "@airgap/beacon-sdk",
   "version": "1.1.0",
   "description": "The beacon-sdk allows you to easily connect DApps with Wallets through P2P communication or a chrome extension.",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "unpkg": "dist/beacon.min.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/cjs/index.d.ts",
   "keywords": [
     "airgap",
     "beacon",
@@ -22,8 +23,8 @@
     "url": "https://github.com/airgap-it/beacon-sdk"
   },
   "scripts": {
-    "build": "tsc && npm run browserify",
-    "browserify": "browserify ./dist/index.js -s beacon | uglifyjs > ./dist/beacon.min.js",
+    "build": "tsc -p tsconfig.json && tsc -p ./tsconfig-cjs.json && npm run browserify",
+    "browserify": "browserify ./dist/cjs/index.js -s beacon | uglifyjs > ./dist/beacon.min.js",
     "prettier": "prettier --write 'src/**/*' 'docs/**/*.md'",
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' --fix",
@@ -35,7 +36,7 @@
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:deploy": "./deploy-docs.sh",
-    "check-version": "ts-node scripts/check-sdk-version.ts"
+    "check-version": "ts-node --project tsconfig-cjs.json scripts/check-sdk-version.ts"
   },
   "author": "Papers GmbH <contact@papers.ch> (https://papers.ch)",
   "dependencies": {

--- a/src/utils/qr.ts
+++ b/src/utils/qr.ts
@@ -1,4 +1,4 @@
-import * as qrcode from 'qrcode-generator'
+import qrcode from 'qrcode-generator'
 
 export const getQrData = (payload: string, type?: 'data' | 'svg' | 'ascii'): string => {
   const typeNumber: TypeNumber = 0

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": ["es2015", "es2017.string", "dom"],
-    "module": "commonjs",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "declaration": true,
-    "outDir": "./dist",
+    "outDir": "./dist/esm",
     "typeRoots": ["./node_modules/@types", "./src/typings"],
     "sourceMap": true,
     /* Strict Type-Checking Options */


### PR DESCRIPTION
Hello! I'm currently using Beacon in a project that uses the [Snowpack](https://www.snowpack.dev/) build tool, which relies on native browser support for [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules). I noticed some problems when importing Beacon as it currently only builds CommonJS modules.

Thankfully TypeScript makes compiling ES Modules alongside CommonJS builds pretty straightforward, so I made the following configuration changes which seem to resolve my issue and maintain compatibility with the existing build.

Let me know how this looks and whether I need to make additional changes to fully support each workflow.

Thanks!