### PR TITLE
chore(deps) update libsodium to 0.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9819,16 +9819,16 @@
       }
     },
     "libsodium": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.6.tgz",
-      "integrity": "sha512-hPb/04sEuLcTRdWDtd+xH3RXBihpmbPCsKW/Jtf4PsvdyKh+D6z2D2gvp/5BfoxseP+0FCOg66kE+0oGUE/loQ=="
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
+      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ=="
     },
     "libsodium-wrappers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.6.tgz",
-      "integrity": "sha512-OUO2CWW5bHdLr6hkKLHIKI4raEkZrf3QHkhXsJ1yCh6MZ3JDA7jFD3kCATNquuGSG6MjjPHQIQms0y0gBDzjQg==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
+      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
       "requires": {
-        "libsodium": "0.7.6"
+        "libsodium": "0.7.8"
       }
     },
     "lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "axios": "0.19.2",
     "bignumber.js": "9.0.0",
     "bs58check": "2.1.2",
-    "libsodium-wrappers": "0.7.6",
+    "libsodium-wrappers": "0.7.8",
     "qrcode-generator": "1.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
We got reports that using taquito and beacon resulted in two instances of `libsodium-wrappers` getting loaded. We should try co-ordinate to keep our packages dependency on `libsodium-wrappers` in sync.
