### PR TITLE
fix(postmessage): use specific identity instead of wildcard as recipient

### DIFF
--- a/src/transports/PostMessageTransport.ts
+++ b/src/transports/PostMessageTransport.ts
@@ -62,7 +62,7 @@ export class PostMessageTransport extends Transport {
         payload: 'ping'
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      myWindow.postMessage(message as any, '*')
+      myWindow.postMessage(message as any, window.location.origin)
     })
   }
 

--- a/src/transports/clients/PostMessageClient.ts
+++ b/src/transports/clients/PostMessageClient.ts
@@ -55,7 +55,8 @@ export class PostMessageClient extends MessageBasedClient {
       encryptedPayload: payload
     }
 
-    myWindow.postMessage(msg as any, '*')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    myWindow.postMessage(msg as any, window.location.origin)
   }
 
   public async listenForChannelOpening(
@@ -99,7 +100,7 @@ export class PostMessageClient extends MessageBasedClient {
       payload: await new Serializer().serialize(await this.getHandshakeInfo())
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    myWindow.postMessage(message as any, '*')
+    myWindow.postMessage(message as any, window.location.origin)
   }
 
   public async isChannelOpenMessage(message: any): Promise<boolean> {

--- a/test/clients/dapp-client.spec.ts
+++ b/test/clients/dapp-client.spec.ts
@@ -100,7 +100,9 @@ describe(`DAppClient`, () => {
      *
      * We cannot do it globally because it fails in the storage tests because of security policies
      */
-    this.jsdom = require('jsdom-global')()
+    this.jsdom = require('jsdom-global')('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost/'
+    })
   })
 
   after(function () {

--- a/test/clients/wallet-client.spec.ts
+++ b/test/clients/wallet-client.spec.ts
@@ -62,7 +62,9 @@ describe(`WalletClient`, () => {
      *
      * We cannot do it globally because it fails in the storage tests because of security policies
      */
-    this.jsdom = require('jsdom-global')()
+    this.jsdom = require('jsdom-global')('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost/'
+    })
   })
 
   after(function () {

--- a/test/transports/post-message-transport.spec.ts
+++ b/test/transports/post-message-transport.spec.ts
@@ -35,7 +35,9 @@ describe(`PostMessageTransport`, () => {
      *
      * We cannot do it globally because it fails in the storage tests because of security policies
      */
-    this.jsdom = require('jsdom-global')()
+    this.jsdom = require('jsdom-global')('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost/'
+    })
   })
 
   after(function () {


### PR DESCRIPTION
Fixes the sonarcloud "Origins should be verified during cross-origin communications" issue. https://rules.sonarsource.com/javascript/RSPEC-2819