### PR TITLE
feat(toast): include wallet icons for known wallets

### DIFF
--- a/src/clients/beacon-client/BeaconClient.ts
+++ b/src/clients/beacon-client/BeaconClient.ts
@@ -17,6 +17,16 @@ export abstract class BeaconClient {
    */
   public readonly name: string
 
+  /**
+   * The URL of the dApp Icon. This can be used to display the icon of the dApp on in the wallet
+   */
+  public readonly iconUrl?: string
+
+  /**
+   * The URL of the dApp.
+   */
+  public readonly appUrl?: string
+
   /** The beaconId is a public key that is used to identify one specific application (dapp or wallet).
    * This is used inside a message to specify the sender, for example.
    */
@@ -45,6 +55,8 @@ export abstract class BeaconClient {
       throw new Error('Storage not set')
     }
     this.name = config.name
+    this.iconUrl = config.iconUrl
+    this.appUrl = config.appUrl
     this.storage = config.storage
 
     this.initSDK().catch(console.error)

--- a/src/clients/beacon-client/BeaconClientOptions.ts
+++ b/src/clients/beacon-client/BeaconClientOptions.ts
@@ -5,6 +5,17 @@ export interface BeaconClientOptions {
    * Name of the application
    */
   name: string
+
+  /**
+   * A URL to the icon of the application
+   */
+  iconUrl?: string
+
+  /**
+   * A URL to the website of the application
+   */
+  appUrl?: string
+
   /**
    * The storage that will be used by the SDK
    */

--- a/src/clients/client/Client.ts
+++ b/src/clients/client/Client.ts
@@ -70,7 +70,7 @@ export abstract class Client extends BeaconClient {
   }
 
   constructor(config: ClientOptions) {
-    super({ name: config.name, storage: config.storage })
+    super(config)
 
     this.events = new BeaconEventHandler(config.eventHandlers, config.disableDefaultEvents ?? false)
     this.accountManager = new AccountManager(config.storage)

--- a/src/clients/client/ClientOptions.ts
+++ b/src/clients/client/ClientOptions.ts
@@ -8,6 +8,16 @@ export interface ClientOptions {
   name: string
 
   /**
+   * A URL to the icon of the application
+   */
+  iconUrl?: string
+
+  /**
+   * A URL to the website of the application
+   */
+  appUrl?: string
+
+  /**
    * The storage that will be used by the SDK
    */
   storage: Storage

--- a/src/clients/dapp-client/DAppClient.ts
+++ b/src/clients/dapp-client/DAppClient.ts
@@ -67,6 +67,7 @@ import { SigningType } from '../../types/beacon/SigningType'
 import { ExtendedPeerInfo } from '../../types/PeerInfo'
 import { ColorMode } from '../../types/ColorMode'
 import { getColorMode, setColorMode } from '../../colorMode'
+import { desktopList, extensionList, iOSList, webList } from '../../ui/alert/wallet-lists'
 import { DAppClientOptions } from './DAppClientOptions'
 
 const logger = new Logger('DAppClient')
@@ -936,14 +937,19 @@ export class DAppClient extends Client {
 
     await (await this.transport).send(payload, peer)
 
-    console.log('peer', peer)
-
     const typedPeer: PostMessagePairingResponse = peer as any
+
+    // TODO: Remove once all wallets send the icon?
+    const selectedApp =
+      iOSList.find((app) => app.name === typedPeer.name) ??
+      webList.find((app) => app.name === typedPeer.name) ??
+      desktopList.find((app) => app.name === typedPeer.name) ??
+      extensionList.find((app) => app.name === typedPeer.name)
 
     this.events
       .emit(messageEvents[requestInput.type].sent, {
         walletName: typedPeer.name,
-        walletIcon: typedPeer.icon,
+        walletIcon: typedPeer.icon ?? selectedApp?.logo,
         resetCallback: async () => {
           await this.clearActiveAccount()
         }

--- a/src/clients/dapp-client/DAppClient.ts
+++ b/src/clients/dapp-client/DAppClient.ts
@@ -78,11 +78,6 @@ const logger = new Logger('DAppClient')
  */
 export class DAppClient extends Client {
   /**
-   * The URL of the dApp Icon. This can be used to display the icon of the dApp on in the wallet
-   */
-  public readonly iconUrl?: string
-
-  /**
    * The block explorer used by the SDK
    */
   public readonly blockExplorer: BlockExplorer
@@ -123,7 +118,6 @@ export class DAppClient extends Client {
       storage: config && config.storage ? config.storage : new LocalStorage(),
       ...config
     })
-    this.iconUrl = config.iconUrl
     this.blockExplorer = config.blockExplorer ?? new TezblockBlockExplorer()
     this.preferredNetwork = config.preferredNetwork ?? NetworkType.MAINNET
     setColorMode(config.colorMode ?? ColorMode.LIGHT)
@@ -221,7 +215,14 @@ export class DAppClient extends Client {
     this.postMessageTransport = new DappPostMessageTransport(this.name, keyPair, this.storage)
     await this.addListener(this.postMessageTransport)
 
-    this.p2pTransport = new DappP2PTransport(this.name, keyPair, this.storage, this.matrixNodes)
+    this.p2pTransport = new DappP2PTransport(
+      this.name,
+      keyPair,
+      this.storage,
+      this.matrixNodes,
+      this.iconUrl,
+      this.appUrl
+    )
     await this.addListener(this.p2pTransport)
   }
 

--- a/src/clients/dapp-client/DAppClientOptions.ts
+++ b/src/clients/dapp-client/DAppClientOptions.ts
@@ -15,6 +15,11 @@ export interface DAppClientOptions {
   iconUrl?: string
 
   /**
+   * A URL to the website of the application
+   */
+  appUrl?: string
+
+  /**
    * The storage that will be used by the SDK
    */
   storage?: Storage

--- a/src/clients/wallet-client/WalletClient.ts
+++ b/src/clients/wallet-client/WalletClient.ts
@@ -56,7 +56,14 @@ export class WalletClient extends Client {
   public async init(): Promise<TransportType> {
     const keyPair = await this.keyPair // We wait for keypair here so the P2P Transport creation is not delayed and causing issues
 
-    const p2pTransport = new WalletP2PTransport(this.name, keyPair, this.storage, this.matrixNodes)
+    const p2pTransport = new WalletP2PTransport(
+      this.name,
+      keyPair,
+      this.storage,
+      this.matrixNodes,
+      this.iconUrl,
+      this.appUrl
+    )
 
     return super.init(p2pTransport)
   }

--- a/src/clients/wallet-client/WalletClientOptions.ts
+++ b/src/clients/wallet-client/WalletClientOptions.ts
@@ -5,10 +5,22 @@ export interface WalletClientOptions {
    * Name of the application
    */
   name: string
+
+  /**
+   * A URL to the icon of the application
+   */
+  iconUrl?: string
+
+  /**
+   * A URL to the website of the application
+   */
+  appUrl?: string
+
   /**
    * The storage that will be used by the SDK
    */
   storage?: Storage
+
   /**
    * A list of matrix nodes the application can use to connect to
    */

--- a/src/transports/DappP2PTransport.ts
+++ b/src/transports/DappP2PTransport.ts
@@ -9,8 +9,15 @@ export class DappP2PTransport extends P2PTransport<
   ExtendedP2PPairingResponse,
   StorageKey.TRANSPORT_P2P_PEERS_DAPP
 > {
-  constructor(name: string, keyPair: sodium.KeyPair, storage: Storage, matrixNodes: string[]) {
-    super(name, keyPair, storage, matrixNodes, StorageKey.TRANSPORT_P2P_PEERS_DAPP)
+  constructor(
+    name: string,
+    keyPair: sodium.KeyPair,
+    storage: Storage,
+    matrixNodes: string[],
+    iconUrl?: string,
+    appUrl?: string
+  ) {
+    super(name, keyPair, storage, matrixNodes, StorageKey.TRANSPORT_P2P_PEERS_DAPP, iconUrl, appUrl)
   }
 
   public async startOpenChannelListener(): Promise<void> {

--- a/src/transports/P2PTransport.ts
+++ b/src/transports/P2PTransport.ts
@@ -27,11 +27,13 @@ export class P2PTransport<
     keyPair: sodium.KeyPair,
     storage: Storage,
     matrixNodes: string[],
-    storageKey: K
+    storageKey: K,
+    iconUrl?: string,
+    appUrl?: string
   ) {
     super(
       name,
-      new P2PCommunicationClient(name, keyPair, 1, storage, matrixNodes),
+      new P2PCommunicationClient(name, keyPair, 1, storage, matrixNodes, iconUrl, appUrl),
       new PeerManager<K>(storage, storageKey)
     )
   }

--- a/src/transports/WalletP2PTransport.ts
+++ b/src/transports/WalletP2PTransport.ts
@@ -7,8 +7,23 @@ export class WalletP2PTransport extends P2PTransport<
   P2PPairingRequest,
   StorageKey.TRANSPORT_P2P_PEERS_WALLET
 > {
-  constructor(name: string, keyPair: sodium.KeyPair, storage: Storage, matrixNodes: string[]) {
-    super(name, keyPair, storage, matrixNodes, StorageKey.TRANSPORT_P2P_PEERS_WALLET)
+  constructor(
+    name: string,
+    keyPair: sodium.KeyPair,
+    storage: Storage,
+    matrixNodes: string[],
+    iconUrl?: string,
+    appUrl?: string
+  ) {
+    super(
+      name,
+      keyPair,
+      storage,
+      matrixNodes,
+      StorageKey.TRANSPORT_P2P_PEERS_WALLET,
+      iconUrl,
+      appUrl
+    )
   }
 
   public async addPeer(newPeer: P2PPairingRequest): Promise<void> {

--- a/src/transports/clients/P2PCommunicationClient.ts
+++ b/src/transports/clients/P2PCommunicationClient.ts
@@ -48,7 +48,9 @@ export class P2PCommunicationClient extends CommunicationClient {
     keyPair: sodium.KeyPair,
     public readonly replicationCount: number,
     private readonly storage: Storage,
-    matrixNodes: string[]
+    matrixNodes: string[],
+    private readonly iconUrl?: string,
+    private readonly appUrl?: string
   ) {
     super(keyPair)
 
@@ -57,7 +59,7 @@ export class P2PCommunicationClient extends CommunicationClient {
   }
 
   public async getPairingRequestInfo(): Promise<P2PPairingRequest> {
-    return {
+    const info: P2PPairingRequest = {
       id: await generateGUID(),
       type: 'p2p-pairing-request',
       name: this.name,
@@ -65,10 +67,19 @@ export class P2PCommunicationClient extends CommunicationClient {
       publicKey: await this.getPublicKey(),
       relayServer: await this.getRelayServer()
     }
+
+    if (this.iconUrl) {
+      info.icon = this.iconUrl
+    }
+    if (this.appUrl) {
+      info.appUrl = this.appUrl
+    }
+
+    return info
   }
 
   public async getPairingResponseInfo(request: P2PPairingRequest): Promise<P2PPairingResponse> {
-    return {
+    const info: P2PPairingResponse = {
       id: request.id,
       type: 'p2p-pairing-response',
       name: this.name,
@@ -76,6 +87,15 @@ export class P2PCommunicationClient extends CommunicationClient {
       publicKey: await this.getPublicKey(),
       relayServer: await this.getRelayServer()
     }
+
+    if (this.iconUrl) {
+      info.icon = this.iconUrl
+    }
+    if (this.appUrl) {
+      info.appUrl = this.appUrl
+    }
+
+    return info
   }
 
   public async getRelayServer(publicKeyHash?: string, nonce: string = ''): Promise<string> {


### PR DESCRIPTION
This PR does 2 things:
- Select default icons/logos for wallets that we have icons locally (eg. AirGap Wallet, Kukai, Beacon Extension)
- Include icons in pairing request/response