### PR TITLE
fix(dapp-client): persist active peer after active account has been set

### DIFF
--- a/src/clients/dapp-client/DAppClient.ts
+++ b/src/clients/dapp-client/DAppClient.ts
@@ -385,7 +385,10 @@ export class DAppClient extends Client {
       } else if (origin === Origin.P2P) {
         await this.setTransport(this.p2pTransport)
       }
+      const peer = await this.getPeer(account)
+      await this.setActivePeer(peer as any)
     } else {
+      await this.setActivePeer(undefined)
       await this.setTransport(undefined)
     }
 


### PR DESCRIPTION
Tests are fixed in the parent branch