### PR TITLE
Feat/multi node support

### DIFF
--- a/example-dapp.html
+++ b/example-dapp.html
@@ -18,6 +18,7 @@
       div {
         background-color: red;
       }
+
       span {
         background-color: orange;
       }
@@ -96,8 +97,10 @@
     <script>
       // Initiate DAppClient
       const client = new beacon.DAppClient({
-        name: 'Example DApp' // Name of the DApp,
+        name: 'Example DApp', // Name of the DApp,
         // preferredNetwork: beacon.NetworkType.DELPHINET
+        matrixNodes: ['matrix.papers.tech']
+        // matrixNodes: ['beacon.tztip.me']
       })
 
       // Display the active account in the UI

--- a/example-wallet.html
+++ b/example-wallet.html
@@ -18,6 +18,8 @@
   <body>
     Beacon Example Wallet
     <br /><br />
+    <div id="status"></div>
+    <br /><br />
     <button id="paste">Paste Sync Code</button>
     <br /><br />
     ---
@@ -31,8 +33,14 @@
     <script>
       // Initiate DAppClient
       const client = new beacon.WalletClient({
-        name: 'Example Wallet' // Name of the DApp
+        name: 'Example Wallet', // Name of the DApp
+        matrixNodes: ['matrix.papers.tech']
+        // matrixNodes: ['beacon.tztip.me']
       })
+
+      const setStatus = (status) => {
+        document.getElementById('status').innerHTML = status ? 'Status: ' + status : status
+      }
 
       // Add event listener to the button
       document.getElementById('paste').addEventListener('click', () => {
@@ -42,7 +50,9 @@
             .deserialize(clipText)
             .then((peer) => {
               console.log('Adding peer', peer)
+              setStatus('Connecting...')
               client.addPeer(peer).then(() => {
+                setStatus('')
                 console.log('Peer added')
               })
             })
@@ -54,6 +64,8 @@
         console.log('init')
         client
           .connect(async (message) => {
+            setStatus('Handling request...')
+
             console.log('message', message)
             // Example: Handle PermissionRequest. A wallet should handle all request types
             if (message.type === beacon.BeaconMessageType.PermissionRequest) {
@@ -74,7 +86,16 @@
               client.respond(response)
             } else {
               console.error('Only permission requests are supported in this demo')
+
+              const response = {
+                type: beacon.BeaconMessageType.Error,
+                id: message.id,
+                errorType: beacon.BeaconErrorType.ABORTED_ERROR
+              }
+              client.respond(response)
             }
+
+            setStatus('')
           })
           .catch((error) => console.error('connect error', error))
       }) // Establish P2P connection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.3",
+  "version": "2.2.4-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.3",
+  "version": "2.2.4-beta.0",
   "description": "The beacon-sdk allows you to easily connect DApps with Wallets through P2P communication or a chrome extension.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION: string = '2.2.3'
+export const SDK_VERSION: string = '2.2.4-beta.0'
 export const BEACON_VERSION: string = '2'

--- a/src/matrix-client/MatrixClient.ts
+++ b/src/matrix-client/MatrixClient.ts
@@ -207,7 +207,7 @@ export class MatrixClient {
         (roomsOrIds as any[]).map((roomOrId) => {
           const room = this.store.getRoom(roomOrId)
 
-          return this.roomService.joinRoom(accessToken, room).catch((error) => console.warn(error))
+          return this.roomService.joinRoom(accessToken, room)
         })
       )
     )

--- a/src/matrix-client/services/MatrixEventService.ts
+++ b/src/matrix-client/services/MatrixEventService.ts
@@ -97,7 +97,7 @@ export class MatrixEventService {
 
     try {
       const response = await this.httpClient.put<MatrixEventSendResponse>(
-        `/rooms/${roomId}/send/${type}/${txnId}`,
+        `/rooms/${encodeURIComponent(roomId)}/send/${type}/${encodeURIComponent(txnId)}`,
         content,
         { accessToken }
       )

--- a/src/matrix-client/services/MatrixRoomService.ts
+++ b/src/matrix-client/services/MatrixRoomService.ts
@@ -40,7 +40,11 @@ export class MatrixRoomService {
       return Promise.reject(`User is not a member of room ${room.id}.`)
     }
 
-    return this.httpClient.post(`/rooms/${room.id}/invite`, { user_id: user }, { accessToken })
+    return this.httpClient.post(
+      `/rooms/${encodeURIComponent(room.id)}/invite`,
+      { user_id: user },
+      { accessToken }
+    )
   }
 
   /**
@@ -54,7 +58,7 @@ export class MatrixRoomService {
       return Promise.resolve({ room_id: room.id })
     }
 
-    return this.httpClient.post(`/rooms/${room.id}/join`, {}, { accessToken })
+    return this.httpClient.post(`/rooms/${encodeURIComponent(room.id)}/join`, {}, { accessToken })
   }
 
   /**

--- a/src/transports/clients/P2PCommunicationClient.ts
+++ b/src/transports/clients/P2PCommunicationClient.ts
@@ -364,7 +364,7 @@ export class P2PCommunicationClient extends CommunicationClient {
           }, 100 * (retry > 50 ? 10 : 1)) // After the initial 5 seconds, retry only once per second
         })
       } else {
-        new Error(`Noone joined after ${retry} tries.`)
+        throw new Error(`No one joined after ${retry} tries.`)
       }
     }
   }


### PR DESCRIPTION
This PR adds multi node support. It fixes a bug where the wrong recipient server was used and adds some "retry" functionality where it's now necessary because of the federation delays.