### PR TITLE
feat(matrix): add stop method to cancel network requests

### DIFF
--- a/example-wallet.html
+++ b/example-wallet.html
@@ -1,126 +1,124 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Style-Type" content="text/css" />
+    <title>Beacon Example Wallet</title>
 
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <title>Beacon Example Wallet</title>
+    <script>
+      // This will enable the debug mode of beacon
+      // This should only be used during development
+      window.beaconSdkDebugEnabled = true
+    </script>
 
-  <script>
-    // This will enable the debug mode of beacon
-    // This should only be used during development
-    window.beaconSdkDebugEnabled = true
-  </script>
+    <script src="./dist/walletbeacon.min.js"></script>
+  </head>
 
-  <script src="./dist/walletbeacon.min.js"></script>
-</head>
+  <body>
+    Beacon Example Wallet
+    <br /><br />
+    <div id="status"></div>
+    <br /><br />
+    <button id="paste">Paste Sync Code</button>
+    <br /><br />
+    ---
+    <br /><br />
+    <button id="removePeer">Remove Peer</button>
+    <br /><br />
+    ---
+    <br /><br />
+    <button id="reset">Reset and Refresh</button>
 
-<body>
-  Beacon Example Wallet
-  <br /><br />
-  <div id="status"></div>
-  <br /><br />
-  <button id="paste">Paste Sync Code</button>
-  <br /><br />
-  ---
-  <br /><br />
-  <button id="removePeer">Remove Peer</button>
-  <br /><br />
-  ---
-  <br /><br />
-  <button id="reset">Reset and Refresh</button>
+    <script>
+      // Initiate DAppClient
+      const client = new beacon.WalletClient({
+        name: 'Example Wallet', // Name of the DApp
+        matrixNodes: ['matrix.papers.tech']
+        // matrixNodes: ['beacon.tztip.me']
+      })
 
-  <script>
-    // Initiate DAppClient
-    const client = new beacon.WalletClient({
-      name: 'Example Wallet', // Name of the DApp
-      matrixNodes: ['matrix.papers.tech']
-      // matrixNodes: ['beacon.tztip.me']
-    })
+      const setStatus = (status) => {
+        document.getElementById('status').innerHTML = status ? 'Status: ' + status : status
+      }
 
-    const setStatus = (status) => {
-      document.getElementById('status').innerHTML = status ? 'Status: ' + status : status
-    }
-
-    // Add event listener to the button
-    document.getElementById('paste').addEventListener('click', () => {
-      navigator.clipboard.readText().then((clipText) => {
-        const serializer = new beacon.Serializer()
-        serializer
-          .deserialize(clipText)
-          .then((peer) => {
-            console.log('Adding peer', peer)
-            setStatus('Connecting...')
-            client.addPeer(peer).then(() => {
-              setStatus('')
-              console.log('Peer added')
+      // Add event listener to the button
+      document.getElementById('paste').addEventListener('click', () => {
+        navigator.clipboard.readText().then((clipText) => {
+          const serializer = new beacon.Serializer()
+          serializer
+            .deserialize(clipText)
+            .then((peer) => {
+              console.log('Adding peer', peer)
+              setStatus('Connecting...')
+              client.addPeer(peer).then(() => {
+                setStatus('')
+                console.log('Peer added')
+              })
             })
-          })
-          .catch((e) => console.error('not a valid sync code'))
-      })
-    })
-
-    client.init().then(() => {
-      console.log('init')
-      client
-        .connect(async (message) => {
-          setStatus('Handling request...')
-
-          console.log('message', message)
-          // Example: Handle PermissionRequest. A wallet should handle all request types
-          if (message.type === beacon.BeaconMessageType.PermissionRequest) {
-            // Show a UI to the user where he can confirm sharing an account with the DApp
-
-            const response = {
-              type: beacon.BeaconMessageType.PermissionResponse,
-              network: message.network, // Use the same network that the user requested
-              scopes: [beacon.PermissionScope.OPERATION_REQUEST], // Ignore the scopes that have been requested and instead give only operation permissions
-              id: message.id,
-              publicKey: '3b92229274683b338cf8b040cf91ac0f8e19e410f06eda5537ef077e718e0024'
-            }
-
-            // Let's wait a little to make it more natural (to test the UI on the dApp side)
-            await new Promise((resolve) => setTimeout(resolve, 1000))
-
-            // Send response back to DApp
-            client.respond(response)
-          } else {
-            console.error('Only permission requests are supported in this demo')
-
-            const response = {
-              type: beacon.BeaconMessageType.Error,
-              id: message.id,
-              errorType: beacon.BeaconErrorType.ABORTED_ERROR
-            }
-            client.respond(response)
-          }
-
-          setStatus('')
+            .catch((e) => console.error('not a valid sync code'))
         })
-        .catch((error) => console.error('connect error', error))
-    }) // Establish P2P connection
-
-    // Add event listener to the button
-    document.getElementById('reset').addEventListener('click', () => {
-      client.destroy().then(() => {
-        window.location.reload()
       })
-    })
 
-    // Add event listener to the button
-    document.getElementById('removePeer').addEventListener('click', () => {
-      client.getPeers().then((peers) => {
-        if (peers.length > 0) {
-          client.removePeer(peers[0], true).then(() => {
-            console.log('peer removed', peers[0])
+      client.init().then(() => {
+        console.log('init')
+        client
+          .connect(async (message) => {
+            setStatus('Handling request...')
+
+            console.log('message', message)
+            // Example: Handle PermissionRequest. A wallet should handle all request types
+            if (message.type === beacon.BeaconMessageType.PermissionRequest) {
+              // Show a UI to the user where he can confirm sharing an account with the DApp
+
+              const response = {
+                type: beacon.BeaconMessageType.PermissionResponse,
+                network: message.network, // Use the same network that the user requested
+                scopes: [beacon.PermissionScope.OPERATION_REQUEST], // Ignore the scopes that have been requested and instead give only operation permissions
+                id: message.id,
+                publicKey: '3b92229274683b338cf8b040cf91ac0f8e19e410f06eda5537ef077e718e0024'
+              }
+
+              // Let's wait a little to make it more natural (to test the UI on the dApp side)
+              await new Promise((resolve) => setTimeout(resolve, 1000))
+
+              // Send response back to DApp
+              client.respond(response)
+            } else {
+              console.error('Only permission requests are supported in this demo')
+
+              const response = {
+                type: beacon.BeaconMessageType.Error,
+                id: message.id,
+                errorType: beacon.BeaconErrorType.ABORTED_ERROR
+              }
+              client.respond(response)
+            }
+
+            setStatus('')
           })
-        } else {
-          console.log('no peers to be removed')
-        }
-      })
-    })
-  </script>
-</body>
+          .catch((error) => console.error('connect error', error))
+      }) // Establish P2P connection
 
+      // Add event listener to the button
+      document.getElementById('reset').addEventListener('click', () => {
+        client.destroy().then(() => {
+          window.location.reload()
+        })
+      })
+
+      // Add event listener to the button
+      document.getElementById('removePeer').addEventListener('click', () => {
+        client.getPeers().then((peers) => {
+          if (peers.length > 0) {
+            client.removePeer(peers[0], true).then(() => {
+              console.log('peer removed', peers[0])
+            })
+          } else {
+            console.log('no peers to be removed')
+          }
+        })
+      })
+    </script>
+  </body>
 </html>

--- a/example-wallet.html
+++ b/example-wallet.html
@@ -1,124 +1,126 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <title>Beacon Example Wallet</title>
 
-    <script>
-      // This will enable the debug mode of beacon
-      // This should only be used during development
-      window.beaconSdkDebugEnabled = true
-    </script>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <title>Beacon Example Wallet</title>
 
-    <script src="./dist/walletbeacon.min.js"></script>
-  </head>
+  <script>
+    // This will enable the debug mode of beacon
+    // This should only be used during development
+    window.beaconSdkDebugEnabled = true
+  </script>
 
-  <body>
-    Beacon Example Wallet
-    <br /><br />
-    <div id="status"></div>
-    <br /><br />
-    <button id="paste">Paste Sync Code</button>
-    <br /><br />
-    ---
-    <br /><br />
-    <button id="removePeer">Remove Peer</button>
-    <br /><br />
-    ---
-    <br /><br />
-    <button id="reset">Reset and Refresh</button>
+  <script src="./dist/walletbeacon.min.js"></script>
+</head>
 
-    <script>
-      // Initiate DAppClient
-      const client = new beacon.WalletClient({
-        name: 'Example Wallet', // Name of the DApp
-        matrixNodes: ['matrix.papers.tech']
-        // matrixNodes: ['beacon.tztip.me']
-      })
+<body>
+  Beacon Example Wallet
+  <br /><br />
+  <div id="status"></div>
+  <br /><br />
+  <button id="paste">Paste Sync Code</button>
+  <br /><br />
+  ---
+  <br /><br />
+  <button id="removePeer">Remove Peer</button>
+  <br /><br />
+  ---
+  <br /><br />
+  <button id="reset">Reset and Refresh</button>
 
-      const setStatus = (status) => {
-        document.getElementById('status').innerHTML = status ? 'Status: ' + status : status
-      }
+  <script>
+    // Initiate DAppClient
+    const client = new beacon.WalletClient({
+      name: 'Example Wallet', // Name of the DApp
+      matrixNodes: ['matrix.papers.tech']
+      // matrixNodes: ['beacon.tztip.me']
+    })
 
-      // Add event listener to the button
-      document.getElementById('paste').addEventListener('click', () => {
-        navigator.clipboard.readText().then((clipText) => {
-          const serializer = new beacon.Serializer()
-          serializer
-            .deserialize(clipText)
-            .then((peer) => {
-              console.log('Adding peer', peer)
-              setStatus('Connecting...')
-              client.addPeer(peer).then(() => {
-                setStatus('')
-                console.log('Peer added')
-              })
+    const setStatus = (status) => {
+      document.getElementById('status').innerHTML = status ? 'Status: ' + status : status
+    }
+
+    // Add event listener to the button
+    document.getElementById('paste').addEventListener('click', () => {
+      navigator.clipboard.readText().then((clipText) => {
+        const serializer = new beacon.Serializer()
+        serializer
+          .deserialize(clipText)
+          .then((peer) => {
+            console.log('Adding peer', peer)
+            setStatus('Connecting...')
+            client.addPeer(peer).then(() => {
+              setStatus('')
+              console.log('Peer added')
             })
-            .catch((e) => console.error('not a valid sync code'))
-        })
+          })
+          .catch((e) => console.error('not a valid sync code'))
       })
+    })
 
-      client.init().then(() => {
-        console.log('init')
-        client
-          .connect(async (message) => {
-            setStatus('Handling request...')
+    client.init().then(() => {
+      console.log('init')
+      client
+        .connect(async (message) => {
+          setStatus('Handling request...')
 
-            console.log('message', message)
-            // Example: Handle PermissionRequest. A wallet should handle all request types
-            if (message.type === beacon.BeaconMessageType.PermissionRequest) {
-              // Show a UI to the user where he can confirm sharing an account with the DApp
+          console.log('message', message)
+          // Example: Handle PermissionRequest. A wallet should handle all request types
+          if (message.type === beacon.BeaconMessageType.PermissionRequest) {
+            // Show a UI to the user where he can confirm sharing an account with the DApp
 
-              const response = {
-                type: beacon.BeaconMessageType.PermissionResponse,
-                network: message.network, // Use the same network that the user requested
-                scopes: [beacon.PermissionScope.OPERATION_REQUEST], // Ignore the scopes that have been requested and instead give only operation permissions
-                id: message.id,
-                publicKey: '3b92229274683b338cf8b040cf91ac0f8e19e410f06eda5537ef077e718e0024'
-              }
-
-              // Let's wait a little to make it more natural (to test the UI on the dApp side)
-              await new Promise((resolve) => setTimeout(resolve, 1000))
-
-              // Send response back to DApp
-              client.respond(response)
-            } else {
-              console.error('Only permission requests are supported in this demo')
-
-              const response = {
-                type: beacon.BeaconMessageType.Error,
-                id: message.id,
-                errorType: beacon.BeaconErrorType.ABORTED_ERROR
-              }
-              client.respond(response)
+            const response = {
+              type: beacon.BeaconMessageType.PermissionResponse,
+              network: message.network, // Use the same network that the user requested
+              scopes: [beacon.PermissionScope.OPERATION_REQUEST], // Ignore the scopes that have been requested and instead give only operation permissions
+              id: message.id,
+              publicKey: '3b92229274683b338cf8b040cf91ac0f8e19e410f06eda5537ef077e718e0024'
             }
 
-            setStatus('')
-          })
-          .catch((error) => console.error('connect error', error))
-      }) // Establish P2P connection
+            // Let's wait a little to make it more natural (to test the UI on the dApp side)
+            await new Promise((resolve) => setTimeout(resolve, 1000))
 
-      // Add event listener to the button
-      document.getElementById('reset').addEventListener('click', () => {
-        client.destroy().then(() => {
-          window.location.reload()
-        })
-      })
-
-      // Add event listener to the button
-      document.getElementById('removePeer').addEventListener('click', () => {
-        client.getPeers().then((peers) => {
-          if (peers.length > 0) {
-            client.removePeer(peers[0], true).then(() => {
-              console.log('peer removed', peers[0])
-            })
+            // Send response back to DApp
+            client.respond(response)
           } else {
-            console.log('no peers to be removed')
+            console.error('Only permission requests are supported in this demo')
+
+            const response = {
+              type: beacon.BeaconMessageType.Error,
+              id: message.id,
+              errorType: beacon.BeaconErrorType.ABORTED_ERROR
+            }
+            client.respond(response)
           }
+
+          setStatus('')
         })
+        .catch((error) => console.error('connect error', error))
+    }) // Establish P2P connection
+
+    // Add event listener to the button
+    document.getElementById('reset').addEventListener('click', () => {
+      client.destroy().then(() => {
+        window.location.reload()
       })
-    </script>
-  </body>
+    })
+
+    // Add event listener to the button
+    document.getElementById('removePeer').addEventListener('click', () => {
+      client.getPeers().then((peers) => {
+        if (peers.length > 0) {
+          client.removePeer(peers[0], true).then(() => {
+            console.log('peer removed', peers[0])
+          })
+        } else {
+          console.log('no peers to be removed')
+        }
+      })
+    })
+  </script>
+</body>
+
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.4-beta.0",
+  "version": "2.2.4-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.4-beta.0",
+  "version": "2.2.4-beta.1",
   "description": "The beacon-sdk allows you to easily connect DApps with Wallets through P2P communication or a chrome extension.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/clients/client/Client.ts
+++ b/src/clients/client/Client.ts
@@ -175,6 +175,13 @@ export abstract class Client extends BeaconClient {
     return (await this.transport).addPeer(peer)
   }
 
+  public async destroy(): Promise<void> {
+    if (this._transport.status === ExposedPromiseStatus.RESOLVED) {
+      await (await this.transport).disconnect()
+    }
+    await super.destroy()
+  }
+
   /**
    * A "setter" for when the transport needs to be changed.
    */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION: string = '2.2.4-beta.0'
+export const SDK_VERSION: string = '2.2.4-beta.1'
 export const BEACON_VERSION: string = '2'

--- a/src/matrix-client/MatrixClientEventEmitter.ts
+++ b/src/matrix-client/MatrixClientEventEmitter.ts
@@ -58,11 +58,13 @@ export class MatrixClientEventEmitter extends EventEmitter {
    */
   private emitClientEvent<T extends MatrixClientEventType>(
     eventType: T,
-    content: MatrixClientEventContent<T>
+    content: MatrixClientEventContent<T>,
+    timestamp?: number
   ): void {
     this.emit(eventType, {
       type: eventType,
-      content
+      content,
+      timestamp
     })
   }
 
@@ -123,14 +125,21 @@ export class MatrixClientEventEmitter extends EventEmitter {
     stateChange.rooms
       .filter((room) => room.messages.length > 0)
       .map((room) =>
-        room.messages.map((message) => [room.id, message] as [string, MatrixMessage<any>])
+        room.messages.map(
+          (message) =>
+            [room.id, message, message.timestamp] as [string, MatrixMessage<unknown>, number]
+        )
       )
       .reduce((flatten, toFlatten) => flatten.concat(toFlatten), [])
-      .forEach(([roomId, message]) => {
-        this.emitClientEvent(eventType, {
-          roomId,
-          message
-        })
+      .forEach(([roomId, message, timestamp]) => {
+        this.emitClientEvent(
+          eventType,
+          {
+            roomId,
+            message
+          },
+          timestamp
+        )
       })
   }
 }

--- a/src/matrix-client/models/MatrixClientEvent.ts
+++ b/src/matrix-client/models/MatrixClientEvent.ts
@@ -8,7 +8,7 @@ export enum MatrixClientEventType {
 export type MatrixClientEventContent<T> = T extends MatrixClientEventType.INVITE
   ? MatrixClientEventInviteContent
   : T extends MatrixClientEventType.MESSAGE
-  ? MatrixClientEventMessageContent<any>
+  ? MatrixClientEventMessageContent<unknown>
   : never
 
 export interface MatrixClientEventInviteContent {
@@ -23,4 +23,5 @@ export interface MatrixClientEventMessageContent<T> {
 export interface MatrixClientEvent<T extends MatrixClientEventType> {
   type: T
   content: MatrixClientEventContent<T>
+  timestamp?: number
 }

--- a/src/matrix-client/models/MatrixMessage.ts
+++ b/src/matrix-client/models/MatrixMessage.ts
@@ -11,9 +11,14 @@ export class MatrixMessage<T> {
    *
    * @param event
    */
-  public static from(event: MatrixStateEvent): MatrixMessage<any> | undefined {
+  public static from(event: MatrixStateEvent): MatrixMessage<unknown> | undefined {
     if (isTextMessageEvent(event)) {
-      return new MatrixMessage(event.content.msgtype, event.sender, event.content.body)
+      return new MatrixMessage(
+        event.content.msgtype,
+        event.sender,
+        event.content.body,
+        event.origin_server_ts
+      )
     }
 
     // for now only text messages are supported
@@ -23,6 +28,7 @@ export class MatrixMessage<T> {
   private constructor(
     public readonly type: MatrixMessageType,
     public readonly sender: string,
-    public readonly content: T
+    public readonly content: T,
+    public readonly timestamp: number
   ) {}
 }

--- a/src/matrix-client/models/MatrixStateEvent.ts
+++ b/src/matrix-client/models/MatrixStateEvent.ts
@@ -24,4 +24,5 @@ export interface MatrixStateEvent {
   sender: string
   content: unknown
   event_id?: string
+  origin_server_ts: number
 }

--- a/src/transports/P2PTransport.ts
+++ b/src/transports/P2PTransport.ts
@@ -67,7 +67,13 @@ export class P2PTransport<
 
     await this.startOpenChannelListener()
 
-    await super.connect()
+    return super.connect()
+  }
+
+  public async disconnect(): Promise<void> {
+    await this.client.stop()
+
+    return super.disconnect()
   }
 
   public async startOpenChannelListener(): Promise<void> {

--- a/src/transports/Transport.ts
+++ b/src/transports/Transport.ts
@@ -84,6 +84,16 @@ export abstract class Transport<
   }
 
   /**
+   * Disconnect the transport
+   */
+  public async disconnect(): Promise<void> {
+    logger.log('disconnect')
+    this._isConnected = TransportStatus.NOT_CONNECTED
+
+    return
+  }
+
+  /**
    * Send a message through the transport
    *
    * @param message The message to send

--- a/src/transports/clients/P2PCommunicationClient.ts
+++ b/src/transports/clients/P2PCommunicationClient.ts
@@ -36,13 +36,17 @@ const KNOWN_RELAY_SERVERS = [
   // "yadayada.cryptonomic-infra.tech"
 ]
 
+const clientNotReadyError = (): never => {
+  throw new Error('Client not ready. Make sure to call "start" before you try to use it.')
+}
+
 /**
  * @internalapi
  *
  *
  */
 export class P2PCommunicationClient extends CommunicationClient {
-  private readonly clients: MatrixClient[] = []
+  private client: MatrixClient | undefined
 
   private readonly KNOWN_RELAY_SERVERS: string[]
 
@@ -118,19 +122,19 @@ export class P2PCommunicationClient extends CommunicationClient {
     }, Promise.resolve(this.KNOWN_RELAY_SERVERS[0]))
   }
 
-  public async tryJoinRooms(
-    client: MatrixClient,
-    roomId: string,
-    retry: number = 1
-  ): Promise<void> {
+  public async tryJoinRooms(roomId: string, retry: number = 1): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     try {
-      await client.joinRooms(roomId)
+      await this.client.joinRooms(roomId)
     } catch (error) {
       if (retry <= 10 && error.errcode === 'M_FORBIDDEN') {
         // If we join the room too fast after receiving the invite, the server can accidentally reject our join. This seems to be a problem only when using a federated multi-node setup. Usually waiting for a couple milliseconds solves the issue, but to handle lag, we will keep retrying for 2 seconds.
         logger.log(`Retrying to join...`, error)
         setTimeout(async () => {
-          await this.tryJoinRooms(client, roomId, retry + 1)
+          await this.tryJoinRooms(roomId, retry + 1)
         }, 200)
       } else {
         logger.log(`Failed to join after ${retry} tries.`, error)
@@ -151,14 +155,13 @@ export class P2PCommunicationClient extends CommunicationClient {
 
     logger.log('start', `connecting to server`)
 
-    const client = MatrixClient.create({
+    this.client = MatrixClient.create({
       baseUrl: `https://${await this.getRelayServer(await this.getPublicKeyHash(), '0')}`,
       storage: this.storage
     })
-    this.clients.push(client)
 
-    client.subscribe(MatrixClientEventType.INVITE, async (event) => {
-      await this.tryJoinRooms(client, event.content.roomId)
+    this.client.subscribe(MatrixClientEventType.INVITE, async (event) => {
+      await this.tryJoinRooms(event.content.roomId)
     })
 
     logger.log(
@@ -169,7 +172,7 @@ export class P2PCommunicationClient extends CommunicationClient {
       await this.getRelayServer(await this.getPublicKeyHash(), '0')
     )
 
-    await client
+    await this.client
       .start({
         id: await this.getPublicKeyHash(),
         password: `ed:${toHex(rawSignature)}:${await this.getPublicKey()}`,
@@ -177,20 +180,26 @@ export class P2PCommunicationClient extends CommunicationClient {
       })
       .catch((error) => logger.log(error))
 
-    const invitedRooms = await client.invitedRooms
-    await client.joinRooms(...invitedRooms).catch((error) => logger.log(error))
+    const invitedRooms = await this.client.invitedRooms
+    await this.client.joinRooms(...invitedRooms).catch((error) => logger.log(error))
   }
 
   public async stop(): Promise<void> {
-    for (const client of this.clients) {
-      client.stop().catch((error) => logger.error(error))
+    if (!this.client) {
+      throw clientNotReadyError()
     }
+
+    this.client.stop().catch((error) => logger.error(error))
   }
 
   public async listenForEncryptedMessage(
     senderPublicKey: string,
     messageCallback: (message: string) => void
   ): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     if (this.activeListeners.has(senderPublicKey)) {
       return
     }
@@ -235,28 +244,30 @@ export class P2PCommunicationClient extends CommunicationClient {
 
     this.activeListeners.set(senderPublicKey, callbackFunction)
 
-    for (const client of this.clients) {
-      client.subscribe(MatrixClientEventType.MESSAGE, callbackFunction)
-    }
+    this.client.subscribe(MatrixClientEventType.MESSAGE, callbackFunction)
   }
 
   public async unsubscribeFromEncryptedMessage(senderPublicKey: string): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     const listener = this.activeListeners.get(senderPublicKey)
     if (!listener) {
       return
     }
 
-    for (const client of this.clients) {
-      client.unsubscribe(MatrixClientEventType.MESSAGE, listener)
-    }
+    this.client.unsubscribe(MatrixClientEventType.MESSAGE, listener)
 
     this.activeListeners.delete(senderPublicKey)
   }
 
   public async unsubscribeFromEncryptedMessages(): Promise<void> {
-    for (const client of this.clients) {
-      client.unsubscribe(MatrixClientEventType.MESSAGE)
+    if (!this.client) {
+      throw clientNotReadyError()
     }
+
+    this.client.unsubscribe(MatrixClientEventType.MESSAGE)
 
     this.activeListeners.clear()
   }
@@ -265,41 +276,45 @@ export class P2PCommunicationClient extends CommunicationClient {
     message: string,
     peer: P2PPairingRequest | ExtendedP2PPairingResponse
   ): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     const { sharedTx } = await this.createCryptoBoxClient(peer.publicKey, this.keyPair.privateKey)
 
-    for (let i = 0; i < this.replicationCount; i++) {
-      const recipientHash: string = await getHexHash(Buffer.from(peer.publicKey, 'hex'))
-      const recipient = recipientString(recipientHash, peer.relayServer)
+    const recipientHash: string = await getHexHash(Buffer.from(peer.publicKey, 'hex'))
+    const recipient = recipientString(recipientHash, peer.relayServer)
 
-      for (const client of this.clients) {
-        const roomId = await this.getRelevantRoom(client, recipient)
+    const roomId = await this.getRelevantRoom(recipient)
 
-        const encryptedMessage = await encryptCryptoboxPayload(message, sharedTx)
+    const encryptedMessage = await encryptCryptoboxPayload(message, sharedTx)
 
-        // logger.log(
-        //   'sendMessage',
-        //   'sending encrypted message',
-        //   peer.publicKey,
-        //   roomId,
-        //   message,
-        //   await new Serializer().deserialize(message)
-        // )
+    // logger.log(
+    //   'sendMessage',
+    //   'sending encrypted message',
+    //   peer.publicKey,
+    //   roomId,
+    //   message,
+    //   await new Serializer().deserialize(message)
+    // )
 
-        client.sendTextMessage(roomId, encryptedMessage).catch(async (error) => {
-          if (error.errcode === 'M_FORBIDDEN') {
-            // Room doesn't exist
-            logger.log(`sendMessage`, `M_FORBIDDEN`, error)
-            await this.deleteRoomIdFromRooms(roomId)
-            const newRoomId = await this.getRelevantRoom(client, recipient)
-            client.sendTextMessage(newRoomId, encryptedMessage).catch(async (error2) => {
-              logger.log(`sendMessage`, `inner error`, error2)
-            })
-          } else {
-            logger.log(`sendMessage`, `not forbidden`, error)
-          }
+    this.client.sendTextMessage(roomId, encryptedMessage).catch(async (error) => {
+      if (error.errcode === 'M_FORBIDDEN') {
+        // Room doesn't exist
+        logger.log(`sendMessage`, `M_FORBIDDEN`, error)
+        await this.deleteRoomIdFromRooms(roomId)
+        const newRoomId = await this.getRelevantRoom(recipient)
+
+        if (!this.client) {
+          throw clientNotReadyError()
+        }
+        this.client.sendTextMessage(newRoomId, encryptedMessage).catch(async (error2) => {
+          logger.log(`sendMessage`, `inner error`, error2)
         })
+      } else {
+        logger.log(`sendMessage`, `not forbidden`, error)
       }
-    }
+    })
   }
 
   public async deleteRoomIdFromRooms(roomId: string): Promise<void> {
@@ -318,40 +333,46 @@ export class P2PCommunicationClient extends CommunicationClient {
   public async listenForChannelOpening(
     messageCallback: (pairingResponse: ExtendedP2PPairingResponse) => void
   ): Promise<void> {
-    for (const client of this.clients) {
-      client.subscribe(MatrixClientEventType.MESSAGE, async (event) => {
-        if (this.isTextMessage(event.content) && (await this.isChannelOpenMessage(event.content))) {
-          logger.log(`listenForChannelOpening`, `channel opening`, JSON.stringify(event))
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
 
-          const splits = event.content.message.content.split(':')
-          const payload = Buffer.from(splits[splits.length - 1], 'hex')
+    this.client.subscribe(MatrixClientEventType.MESSAGE, async (event) => {
+      if (this.isTextMessage(event.content) && (await this.isChannelOpenMessage(event.content))) {
+        logger.log(`listenForChannelOpening`, `channel opening`, JSON.stringify(event))
 
-          if (
-            payload.length >=
-            sodium.crypto_secretbox_NONCEBYTES + sodium.crypto_secretbox_MACBYTES
-          ) {
-            try {
-              const pairingResponse: P2PPairingResponse = JSON.parse(
-                await openCryptobox(payload, this.keyPair.publicKey, this.keyPair.privateKey)
-              )
+        const splits = event.content.message.content.split(':')
+        const payload = Buffer.from(splits[splits.length - 1], 'hex')
 
-              messageCallback({
-                ...pairingResponse,
-                senderId: await getSenderId(pairingResponse.publicKey)
-              })
-            } catch (decryptionError) {
-              /* NO-OP. We try to decode every message, but some might not be addressed to us. */
-            }
+        if (
+          payload.length >=
+          sodium.crypto_secretbox_NONCEBYTES + sodium.crypto_secretbox_MACBYTES
+        ) {
+          try {
+            const pairingResponse: P2PPairingResponse = JSON.parse(
+              await openCryptobox(payload, this.keyPair.publicKey, this.keyPair.privateKey)
+            )
+
+            messageCallback({
+              ...pairingResponse,
+              senderId: await getSenderId(pairingResponse.publicKey)
+            })
+          } catch (decryptionError) {
+            /* NO-OP. We try to decode every message, but some might not be addressed to us. */
           }
         }
-      })
-    }
+      }
+    })
   }
 
-  public async waitForJoin(client: MatrixClient, roomId: string, retry: number = 0): Promise<void> {
+  public async waitForJoin(roomId: string, retry: number = 0): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     // Rooms are updated as new events come in. `client.getRoomById` only accesses memory, it does not do any network requests.
     // TODO: Improve to listen to "JOIN" event
-    const room = await client.getRoomById(roomId)
+    const room = await this.client.getRoomById(roomId)
     logger.log(`waitForJoin`, `Currently ${room.members.length} members, we need at least 2`)
     if (room.members.length >= 2) {
       return
@@ -362,7 +383,7 @@ export class P2PCommunicationClient extends CommunicationClient {
 
         return new Promise((resolve) => {
           setTimeout(async () => {
-            resolve(this.waitForJoin(client, roomId, retry + 1))
+            resolve(this.waitForJoin(roomId, retry + 1))
           }, 100 * (retry > 50 ? 10 : 1)) // After the initial 5 seconds, retry only once per second
         })
       } else {
@@ -372,32 +393,33 @@ export class P2PCommunicationClient extends CommunicationClient {
   }
 
   public async sendPairingResponse(pairingRequest: P2PPairingRequest): Promise<void> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
     logger.log(`sendPairingResponse`)
     const recipientHash = await getHexHash(Buffer.from(pairingRequest.publicKey, 'hex'))
     const recipient = recipientString(recipientHash, pairingRequest.relayServer)
 
-    logger.log(`sendPairingResponse`, `currently there are ${this.clients.length} clients open`)
-    for (const client of this.clients) {
-      const roomId = await this.getRelevantRoom(client, recipient)
+    const roomId = await this.getRelevantRoom(recipient)
 
-      // Before we send the message, we have to wait for the join to be accepted.
-      await this.waitForJoin(client, roomId)
+    // Before we send the message, we have to wait for the join to be accepted.
+    await this.waitForJoin(roomId)
 
-      // TODO: remove v1 backwards-compatibility
-      const message: string =
-        typeof pairingRequest.version === 'undefined'
-          ? await this.getPublicKey() // v1
-          : JSON.stringify(await this.getPairingResponseInfo(pairingRequest)) // v2
+    // TODO: remove v1 backwards-compatibility
+    const message: string =
+      typeof pairingRequest.version === 'undefined'
+        ? await this.getPublicKey() // v1
+        : JSON.stringify(await this.getPairingResponseInfo(pairingRequest)) // v2
 
-      const encryptedMessage: string = await this.encryptMessageAsymmetric(
-        pairingRequest.publicKey,
-        message
-      )
+    const encryptedMessage: string = await this.encryptMessageAsymmetric(
+      pairingRequest.publicKey,
+      message
+    )
 
-      client
-        .sendTextMessage(roomId, ['@channel-open', recipient, encryptedMessage].join(':'))
-        .catch((error) => logger.log(error))
-    }
+    this.client
+      .sendTextMessage(roomId, ['@channel-open', recipient, encryptedMessage].join(':'))
+      .catch((error) => logger.log(error))
   }
 
   public isTextMessage(
@@ -432,13 +454,13 @@ export class P2PCommunicationClient extends CommunicationClient {
     return difference.absoluteValue()
   }
 
-  private async getRelevantRoom(client: MatrixClient, recipient: string): Promise<string> {
+  private async getRelevantRoom(recipient: string): Promise<string> {
     const roomIds = await this.storage.get(StorageKey.MATRIX_PEER_ROOM_IDS)
     let roomId = roomIds[recipient]
 
     if (!roomId) {
       logger.log(`getRelevantRoom`, `No room found for peer ${recipient}, checking joined ones.`)
-      const room = await this.getRelevantJoinedRoom(client, recipient)
+      const room = await this.getRelevantJoinedRoom(recipient)
       roomId = room.id
       roomIds[recipient] = room.id
       await this.storage.set(StorageKey.MATRIX_PEER_ROOM_IDS, roomIds)
@@ -449,11 +471,12 @@ export class P2PCommunicationClient extends CommunicationClient {
     return roomId
   }
 
-  private async getRelevantJoinedRoom(
-    client: MatrixClient,
-    recipient: string
-  ): Promise<MatrixRoom> {
-    const joinedRooms = await client.joinedRooms
+  private async getRelevantJoinedRoom(recipient: string): Promise<MatrixRoom> {
+    if (!this.client) {
+      throw clientNotReadyError()
+    }
+
+    const joinedRooms = await this.client.joinedRooms
     logger.log('checking joined rooms', joinedRooms, recipient)
     const relevantRooms = joinedRooms.filter((roomElement: MatrixRoom) =>
       roomElement.members.some((member: string) => member === recipient)
@@ -463,8 +486,8 @@ export class P2PCommunicationClient extends CommunicationClient {
     if (relevantRooms.length === 0) {
       logger.log(`getRelevantJoinedRoom`, `no relevant rooms found`)
 
-      const roomId = await client.createTrustedPrivateRoom(recipient)
-      room = await client.getRoomById(roomId)
+      const roomId = await this.client.createTrustedPrivateRoom(recipient)
+      room = await this.client.getRoomById(roomId)
       logger.log(`getRelevantJoinedRoom`, room)
     } else {
       room = relevantRooms[0]

--- a/test/transports/p2p-transport.spec.ts
+++ b/test/transports/p2p-transport.spec.ts
@@ -74,6 +74,9 @@ describe(`P2PTransport`, () => {
       .throws('listenForNewPeer should not be called')
 
     const startClientStub = sinon.stub(P2PCommunicationClient.prototype, 'start').resolves()
+    const listenForChannelOpeningStub = sinon
+      .stub(P2PCommunicationClient.prototype, 'listenForChannelOpening')
+      .resolves()
     sinon.stub(PeerManager.prototype, 'getPeers').resolves([pairingResponse, pairingResponse])
 
     const listenStub = sinon.stub(transport, <any>'listen').resolves()
@@ -83,6 +86,7 @@ describe(`P2PTransport`, () => {
     await transport.connect()
 
     expect(startClientStub.callCount).to.equal(1)
+    expect(listenForChannelOpeningStub.callCount).to.equal(1)
     expect(listenForNewPeerStub.callCount).to.equal(0)
     expect(listenStub.callCount).to.equal(2)
     expect(transport.connectionStatus).to.equal(TransportStatus.CONNECTED)


### PR DESCRIPTION
This PR adds a couple of things:
- Disconnect capability on the P2P Transport. If this is called (eg. when calling .destroy() on the client), the polling is stopped and the current requests are cancelled.
- An "isConnected()" method was added to the MatrixClient. This is used to make sure that the login and initial sync with the matrix node has actually happened before we allow any public methods to be called. Without this change, messages would sometimes be sent before the login happened and would be lost.
- The "timestamp" of the message is now tracked and the last unhandled message that has happened before the login will be handled once the client is ready.