### PR TITLE
feat(p2p): create standby room

### DIFF
--- a/src/transports/P2PTransport.ts
+++ b/src/transports/P2PTransport.ts
@@ -34,11 +34,12 @@ export class P2PTransport<
     matrixNodes: string[],
     storageKey: K,
     iconUrl?: string,
-    appUrl?: string
+    appUrl?: string,
+    isWallet: boolean = false
   ) {
     super(
       name,
-      new P2PCommunicationClient(name, keyPair, 1, storage, matrixNodes, iconUrl, appUrl),
+      new P2PCommunicationClient(name, keyPair, 1, storage, matrixNodes, iconUrl, appUrl, isWallet),
       new PeerManager<K>(storage, storageKey)
     )
   }

--- a/src/transports/WalletP2PTransport.ts
+++ b/src/transports/WalletP2PTransport.ts
@@ -27,7 +27,8 @@ export class WalletP2PTransport extends P2PTransport<
       matrixNodes,
       StorageKey.TRANSPORT_P2P_PEERS_WALLET,
       iconUrl,
-      appUrl
+      appUrl,
+      true
     )
   }
 

--- a/src/types/storage/StorageKey.ts
+++ b/src/types/storage/StorageKey.ts
@@ -14,5 +14,6 @@ export enum StorageKey {
   PERMISSION_LIST = 'beacon:permissions',
   BEACON_SDK_VERSION = 'beacon:sdk_version',
   MATRIX_PRESERVED_STATE = 'beacon:sdk-matrix-preserved-state',
-  MATRIX_PEER_ROOM_IDS = 'beacon:matrix-peer-rooms'
+  MATRIX_PEER_ROOM_IDS = 'beacon:matrix-peer-rooms',
+  MATRIX_ROOM_STANDBY = 'beacon:matrix-standby-room'
 }

--- a/src/types/storage/StorageKeyReturnDefaults.ts
+++ b/src/types/storage/StorageKeyReturnDefaults.ts
@@ -21,5 +21,6 @@ export const defaultValues: StorageKeyReturnDefaults = {
   [StorageKey.PERMISSION_LIST]: [],
   [StorageKey.BEACON_SDK_VERSION]: undefined,
   [StorageKey.MATRIX_PRESERVED_STATE]: {},
-  [StorageKey.MATRIX_PEER_ROOM_IDS]: {}
+  [StorageKey.MATRIX_PEER_ROOM_IDS]: {},
+  [StorageKey.MATRIX_ROOM_STANDBY]: undefined
 }

--- a/src/types/storage/StorageKeyReturnType.ts
+++ b/src/types/storage/StorageKeyReturnType.ts
@@ -28,4 +28,5 @@ export interface StorageKeyReturnType {
   [StorageKey.BEACON_SDK_VERSION]: string | undefined
   [StorageKey.MATRIX_PRESERVED_STATE]: Partial<MatrixState>
   [StorageKey.MATRIX_PEER_ROOM_IDS]: { [key: string]: string | undefined }
+  [StorageKey.MATRIX_ROOM_STANDBY]: string | undefined
 }


### PR DESCRIPTION
This PR adds functionality that always creates a new "standby" room whenever the login is done and no standby room is present. Once a peer is added, instead of creating a new room (which can take a long time), the new peer is instead invited to the standby room.