### PR TITLE
feat(p2p): improve reconnect behaviour

### DIFF
--- a/example-dapp.html
+++ b/example-dapp.html
@@ -86,6 +86,7 @@
     <br /><br />
     <button id="contractCall">Contract Call</button>
     <br /><br />
+    <textarea id="beacon-textbox"></textarea>
     <button id="deserializeData">Deserialize Data</button>
     <br /><br />
     ---
@@ -357,7 +358,9 @@
 
       // Add event listener to the button
       document.getElementById('deserializeData').addEventListener('click', () => {
-        new beacon.Serializer().deserialize('LAB35h7CSZkEZaccyT8UJum46hpUsxxsHUawsB6omEseng3hzGXavcUxg4w8GWkNK2r7kJuyfbfhcgpfA2oWcQhuEaXKjQqyr4Sp6LbEqEJHZnvBTLXi4i2mzoNq4iQct9eKYx9x6eQK6g7z8LJMSmPba67BN7digh2c32mMNJqfNQsq6kjxbDduFySvvvLprXfRc25zfUGXUvbMhKYpxC2Mtyd64QEWQ6us2za4wWG8fFspGykWjmzU3pxqDQsWFUtwi8nyRqSKVDtr1B7KEtmKivQkHUBVroN7HpWurvHsUsieVy').then(console.log).catch(console.error)
+        const value = document.getElementById('beacon-textbox').value
+        console.log('Deserializing:', value)
+        new beacon.Serializer().deserialize(value).then(console.log).catch(console.error)
       })
     </script>
   </body>

--- a/example-dapp.html
+++ b/example-dapp.html
@@ -98,9 +98,9 @@
     <script>
       // Initiate DAppClient
       const client = new beacon.DAppClient({
-        name: 'Example DApp', // Name of the DApp,
+        name: 'Example DApp' // Name of the DApp,
         // preferredNetwork: beacon.NetworkType.DELPHINET
-        matrixNodes: ['test.papers.tech', 'test2.papers.tech', 'matrix.papers.tech']
+        // matrixNodes: ['test.papers.tech', 'test2.papers.tech', 'matrix.papers.tech']
         // matrixNodes: ['beacon-node-0.papers.tech:8448']
         // matrixNodes: ['matrix.papers.tech']
         // matrixNodes: ['beacon.tztip.me']

--- a/example-wallet.html
+++ b/example-wallet.html
@@ -33,8 +33,8 @@
     <script>
       // Initiate DAppClient
       const client = new beacon.WalletClient({
-        name: 'Example Wallet', // Name of the DApp
-        matrixNodes: ['matrix.papers.tech']
+        name: 'Example Wallet' // Name of the DApp
+        // matrixNodes: ['matrix.papers.tech']
         // matrixNodes: ['beacon-node-0.papers.tech:8448']
         // matrixNodes: ['beacon.tztip.me']
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.7-beta.0",
+  "version": "2.2.7-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgap/beacon-sdk",
-  "version": "2.2.7-beta.0",
+  "version": "2.2.7-beta.1",
   "description": "The beacon-sdk allows you to easily connect DApps with Wallets through P2P communication or a chrome extension.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION: string = '2.2.7-beta.0'
+export const SDK_VERSION: string = '2.2.7-beta.1'
 export const BEACON_VERSION: string = '2'

--- a/src/matrix-client/MatrixClientEventEmitter.ts
+++ b/src/matrix-client/MatrixClientEventEmitter.ts
@@ -93,10 +93,11 @@ export class MatrixClientEventEmitter extends EventEmitter {
   ): void {
     stateChange.rooms
       .filter((room) => room.status === MatrixRoomStatus.INVITED)
-      .map((room) => room.id)
-      .forEach((id) => {
+      .map((room) => [room.id, room.members] as [string, string[]])
+      .forEach(([id, members]) => {
         this.emitClientEvent(eventType, {
-          roomId: id
+          roomId: id,
+          members: members
         })
       })
   }

--- a/src/matrix-client/models/MatrixClientEvent.ts
+++ b/src/matrix-client/models/MatrixClientEvent.ts
@@ -13,6 +13,7 @@ export type MatrixClientEventContent<T> = T extends MatrixClientEventType.INVITE
 
 export interface MatrixClientEventInviteContent {
   roomId: string
+  members: string[]
 }
 
 export interface MatrixClientEventMessageContent<T> {

--- a/src/transports/Transport.ts
+++ b/src/transports/Transport.ts
@@ -153,7 +153,6 @@ export abstract class Transport<
   }
 
   public async addPeer(newPeer: T): Promise<void> {
-    console.log('add peer')
     const peer = await this.peerManager.getPeer(newPeer.publicKey)
     if (!peer) {
       logger.log('addPeer', 'adding peer', newPeer)

--- a/src/transports/clients/P2PCommunicationClient.ts
+++ b/src/transports/clients/P2PCommunicationClient.ts
@@ -112,10 +112,37 @@ export class P2PCommunicationClient extends CommunicationClient {
     } else {
       this.relayServer = new ExposedPromise()
     }
+
+    // MIGRATION: If a relay server is set, it's all good and we don't have to do any migration
     const node = await this.storage.get(StorageKey.MATRIX_SELECTED_NODE)
     if (node && node.length > 0) {
       this.relayServer.resolve(node)
       return node
+    } else if (KNOWN_RELAY_SERVERS === this.KNOWN_RELAY_SERVERS) {
+      // Migration start
+      // Only if the array of nodes is the default we do the migration, otherwise we leave it.
+      // If NO relay server is set, we have 3 possibilities:
+
+      const hasDoneMigration = await this.storage.get(StorageKey.MULTI_NODE_SETUP_DONE)
+      if (!hasDoneMigration) {
+        console.log('MIGRATION 2')
+        // If this migration has run before, we can skip it.
+        const preservedState = await this.storage.get(StorageKey.MATRIX_PRESERVED_STATE)
+        console.log('PRESERVED STATE', preservedState)
+        if (preservedState.syncToken || preservedState.rooms) {
+          console.log('MIGRATION 3')
+          // If migration has NOT run and we have a sync state, we know have been previously connected. So we set the old default relayServer as our current node.
+          const node = 'matrix.papers.tech' // 2.2.7 Migration: This will default to the old default to avoid peers from losing their relayServer.
+          this.storage
+            .set(StorageKey.MATRIX_SELECTED_NODE, node)
+            .catch((error) => logger.log(error))
+          this.relayServer.resolve(node)
+          return node
+        }
+
+        this.storage.set(StorageKey.MULTI_NODE_SETUP_DONE, true).catch((error) => logger.log(error))
+        // Migration end
+      }
     }
 
     console.log('GET RELAY SERVER')

--- a/src/types/storage/StorageKey.ts
+++ b/src/types/storage/StorageKey.ts
@@ -15,5 +15,6 @@ export enum StorageKey {
   BEACON_SDK_VERSION = 'beacon:sdk_version',
   MATRIX_PRESERVED_STATE = 'beacon:sdk-matrix-preserved-state',
   MATRIX_PEER_ROOM_IDS = 'beacon:matrix-peer-rooms',
-  MATRIX_SELECTED_NODE = 'beacon:matrix-selected-node'
+  MATRIX_SELECTED_NODE = 'beacon:matrix-selected-node',
+  MULTI_NODE_SETUP_DONE = 'beacon:multi-node-setup'
 }

--- a/src/types/storage/StorageKeyReturnDefaults.ts
+++ b/src/types/storage/StorageKeyReturnDefaults.ts
@@ -22,5 +22,6 @@ export const defaultValues: StorageKeyReturnDefaults = {
   [StorageKey.BEACON_SDK_VERSION]: undefined,
   [StorageKey.MATRIX_PRESERVED_STATE]: {},
   [StorageKey.MATRIX_PEER_ROOM_IDS]: {},
-  [StorageKey.MATRIX_SELECTED_NODE]: undefined
+  [StorageKey.MATRIX_SELECTED_NODE]: undefined,
+  [StorageKey.MULTI_NODE_SETUP_DONE]: undefined
 }

--- a/src/types/storage/StorageKeyReturnType.ts
+++ b/src/types/storage/StorageKeyReturnType.ts
@@ -29,4 +29,5 @@ export interface StorageKeyReturnType {
   [StorageKey.MATRIX_PRESERVED_STATE]: Partial<MatrixState>
   [StorageKey.MATRIX_PEER_ROOM_IDS]: { [key: string]: string | undefined }
   [StorageKey.MATRIX_SELECTED_NODE]: string | undefined
+  [StorageKey.MULTI_NODE_SETUP_DONE]: boolean | undefined
 }

--- a/test/_helpers/_setup.spec.ts
+++ b/test/_helpers/_setup.spec.ts
@@ -22,9 +22,8 @@ const dom = new JSDOM('<!doctype html><html><body></body></html>', {
 // This sets the mock adapter on the default instance
 const mock = new MockAdapter(Axios)
 
-mock
-  .onGet('https://matrix.papers.tech/_matrix/client/versions')
-  .reply(200, {
+const getVersionReply = () => {
+  return {
     versions: ['r0.0.1', 'r0.1.0', 'r0.2.0', 'r0.3.0', 'r0.4.0', 'r0.5.0'],
     unstable_features: {
       'm.lazy_load_members': true,
@@ -32,10 +31,28 @@ mock
       'm.require_identity_server': false,
       'm.separate_add_and_bind': true
     }
-  })
+  }
+}
+const getLogin = (hostname: string) => {
+  console.log('GET LOGIN')
+  return {
+    user_id: `@xxx:${hostname}`,
+    access_token: 'ACCESS_TOKEN',
+    home_server: hostname,
+    device_id: 'xxx'
+  }
+}
+
+mock
+  .onGet('https://matrix.papers.tech/_matrix/client/versions')
+  .reply(200, getVersionReply())
+  .onGet('https://beacon-node-0.papers.tech:8448/_matrix/client/versions')
+  .reply(200, getVersionReply())
+  .onGet('/login')
+  .reply(200, getLogin('matrix.papers.tech'))
   .onAny()
   .reply((config) => {
-    console.log('UNMOCKED URL, RETURNING ERROR 500', config.url)
+    console.log('UNMOCKED URL, RETURNING ERROR 500', `${config.baseURL}${config.url}`)
 
     return [500, {}]
   })

--- a/test/transports/p2p-transport.spec.ts
+++ b/test/transports/p2p-transport.spec.ts
@@ -131,7 +131,7 @@ describe(`P2PTransport`, () => {
     const localStorage = new LocalStorage()
     transport = new WalletP2PTransport('Test', keypair, localStorage, []) as any
 
-    const hasPeerStub = sinon.stub(PeerManager.prototype, 'hasPeer').resolves(false)
+    const getPeerStub = sinon.stub(PeerManager.prototype, 'getPeer').resolves(false)
     const addPeerStub = sinon.stub(PeerManager.prototype, 'addPeer').resolves()
     const listenStub = sinon.stub(transport, <any>'listen').resolves()
     const sendResponseStub = sinon
@@ -140,8 +140,8 @@ describe(`P2PTransport`, () => {
 
     await transport.addPeer(pairingResponse)
 
-    expect(hasPeerStub.callCount, 'hasPeerStub').to.equal(1)
-    expect(hasPeerStub.firstCall.args[0], 'hasPeerStub').to.equal(pairingResponse.publicKey)
+    expect(getPeerStub.callCount, 'getPeerStub').to.equal(1)
+    expect(getPeerStub.firstCall.args[0], 'getPeerStub').to.equal(pairingResponse.publicKey)
     expect(addPeerStub.callCount, 'addPeerStub').to.equal(1)
     expect(addPeerStub.firstCall.args[0], 'addPeerStub').to.equal(pairingResponse)
     expect(listenStub.callCount, 'listenStub').to.equal(1)

--- a/test/transports/post-message-transport.spec.ts
+++ b/test/transports/post-message-transport.spec.ts
@@ -167,14 +167,14 @@ describe(`PostMessageTransport`, () => {
   })
 
   it(`should add peer and start to listen`, async () => {
-    const hasPeerStub = sinon.stub(PeerManager.prototype, 'hasPeer').resolves(false)
+    const getPeerStub = sinon.stub(PeerManager.prototype, 'getPeer').resolves(false)
     const addPeerStub = sinon.stub(PeerManager.prototype, 'addPeer').resolves()
     const listenStub = sinon.stub(transport, <any>'listen').resolves()
 
     await transport.addPeer(pairingResponse)
 
-    expect(hasPeerStub.callCount, 'hasPeerStub').to.equal(1)
-    expect(hasPeerStub.firstCall.args[0], 'hasPeerStub').to.equal(pairingResponse.publicKey)
+    expect(getPeerStub.callCount, 'getPeerStub').to.equal(1)
+    expect(getPeerStub.firstCall.args[0], 'getPeerStub').to.equal(pairingResponse.publicKey)
     expect(addPeerStub.callCount, 'addPeerStub').to.equal(1)
     expect(addPeerStub.firstCall.args[0], 'addPeerStub').to.equal(pairingResponse)
     expect(listenStub.callCount, 'listenStub').to.equal(1)


### PR DESCRIPTION
Test Cases:

- [x] Connect both DApp and Wallet to same server
- [x] Connect DApp to server 1 and Wallet to server 2
- [x] Connect DApp to server 2 and Wallet to server 1
- [x] Connect Dapp and Wallet to server 2
- [x] Connect DApp to server 1 and Wallet to server 2, then bring server 1 down. Refresh the apps and make sure that everything works without interruptions.
- [x] Connect DApp to server 1 and Wallet to server 2, then bring server 2 down. Refresh the apps and make sure that everything works without interruptions.

Tip: To simulate a server being down, simply edit the `beacon:matrix-selected-node` to a URL that does not have a beacon/matrix service running