### PR TITLE
Distribute /src for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "files": [
     "/dist"
+    "/src"
   ],
   "nyc": {
     "include": [


### PR DESCRIPTION
Otherwise sourcemaps don't work