### PR TITLE
feat(alert): improve modal UI

### DIFF
--- a/assets/alert/alert.css
+++ b/assets/alert/alert.css
@@ -235,6 +235,8 @@ button {
 
 #beacon-modal__content {
   padding: 24px;
+  max-height: 340px;
+  overflow-y: auto;
 }
 
 #beacon-switch {


### PR DESCRIPTION
This PR sets a `max-height` and `overflow-y` to the modal wrapper in order to preserve it vertically center to the screen and prevent the content to be cut like in the image above.

<img width="474" alt="Screenshot 2022-11-08 at 17 30 14" src="https://user-images.githubusercontent.com/29119/200621492-1114fdc0-c5bc-4e83-ac3e-12a3f53b1ba8.png">
