### PR TITLE
fix(ui): remove pairing alert overflow

### DIFF
--- a/assets/alert/alert.css
+++ b/assets/alert/alert.css
@@ -44,13 +44,6 @@
   padding: 24px;
 }
 
-@media (min-height: 700px) {
-  .beacon-modal__wrapper {
-    top: 50%;
-    transform: translateY(-50%);
-  }
-}
-
 .theme__light .beacon-modal__base,
 .theme__light .beacon-modal__close__wrapper {
   background: #fff;


### PR DESCRIPTION
Removed conflicting styles for screens with height >700px

Before:
![2023-01-11 14 46 14](https://user-images.githubusercontent.com/25796906/211786900-304f81df-95f7-4176-83e8-a9e59e978282.jpg)

After:
<img width="1440" alt="Screenshot 2023-01-11 at 14 49 24" src="https://user-images.githubusercontent.com/25796906/211787480-63169638-452a-4b28-aa0c-d40b3773bd6f.png">


Probably related: https://github.com/airgap-it/beacon-sdk/pull/406