### PR TITLE
feat: use npm workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "@airgap/beacon-sdk",
       "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
       "dependencies": {
         "@airgap/beacon-blockchain-substrate": "file:packages/beacon-blockchain-substrate",
         "@airgap/beacon-blockchain-tezos": "file:packages/beacon-blockchain-tezos",
@@ -79,25 +82,59 @@
       "resolved": "packages/beacon-dapp",
       "link": true
     },
-    "node_modules/@airgap/beacon-transport-matrix": {
-      "resolved": "packages/beacon-transport-matrix",
+    "node_modules/@airgap/beacon-sdk": {
+      "resolved": "packages/beacon-sdk",
       "link": true
+    },
+    "node_modules/@airgap/beacon-transport-matrix": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.3.2.tgz",
+      "integrity": "sha512-eE6UWuPQus8Z1yG6PpmaDCfiKjtfw0lJtw+KL4qvEsKDzJvhON0q2Wbr8swGxx6KaznA3U8auKg6vZFsDjCViw==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
+        "axios": "0.24.0"
+      }
     },
     "node_modules/@airgap/beacon-transport-postmessage": {
-      "resolved": "packages/beacon-transport-postmessage",
-      "link": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.3.2.tgz",
+      "integrity": "sha512-STgr1fRmIWiUeGWTMhFXzYOvcOnLkEtmREidJvz5Lmts4TKgF6diRPDZa510XnuQoGsyZFnhHq/CQaLY53PfjQ==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
+      }
     },
     "node_modules/@airgap/beacon-types": {
-      "resolved": "packages/beacon-types",
-      "link": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.3.2.tgz",
+      "integrity": "sha512-U4CM2eF04bAG+OGK9SiA32aVVkWBY/CuWfqhOX0T6vI7eRvK2Fc5tmGMp+HBqORBkb5ljPac9T47YUv8Wy/q2w==",
+      "dependencies": {
+        "@types/chrome": "0.0.163"
+      }
     },
     "node_modules/@airgap/beacon-ui": {
-      "resolved": "packages/beacon-ui",
-      "link": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.3.2.tgz",
+      "integrity": "sha512-V9gGZyfsTMIUe3ES10Uls51fp+7B13edPR970Fa4BoZxo6tyL8fPk1dD6plu/pJz2JxUZofpSinDYxW1iquAew==",
+      "dependencies": {
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
+      }
     },
     "node_modules/@airgap/beacon-utils": {
-      "resolved": "packages/beacon-utils",
-      "link": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.3.2.tgz",
+      "integrity": "sha512-nKK5FzluJfX7hgsq+uDeDlUip206G1OkvbvVSBXB4RppBHeg5ApHTvE8+0CMjvas20XMNdosnU5pFed3n4kF4Q==",
+      "dependencies": {
+        "@stablelib/nacl": "^1.0.3",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/utf8": "^1.0.1",
+        "bs58check": "2.1.2"
+      }
     },
     "node_modules/@airgap/beacon-wallet": {
       "resolved": "packages/beacon-wallet",
@@ -15721,38 +15758,38 @@
     },
     "packages/beacon-blockchain-substrate": {
       "name": "@airgap/beacon-blockchain-substrate",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "packages/beacon-blockchain-tezos": {
       "name": "@airgap/beacon-blockchain-tezos",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "packages/beacon-blockchain-tezos-sapling": {
       "name": "@airgap/beacon-blockchain-tezos-sapling",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "packages/beacon-core": {
       "name": "@airgap/beacon-core",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
         "@stablelib/ed25519": "^1.0.3",
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/utf8": "^1.0.1",
@@ -15762,39 +15799,58 @@
     },
     "packages/beacon-dapp": {
       "name": "@airgap/beacon-dapp",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-matrix": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0",
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2",
         "qrcode-generator": "1.4.4"
+      }
+    },
+    "packages/beacon-sdk": {
+      "version": "3.3.2",
+      "license": "ISC",
+      "dependencies": {
+        "@airgap/beacon-blockchain-substrate": "^3.3.2",
+        "@airgap/beacon-blockchain-tezos": "^3.3.2",
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-dapp": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
+        "@airgap/beacon-wallet": "^3.3.2"
       }
     },
     "packages/beacon-transport-matrix": {
       "name": "@airgap/beacon-transport-matrix",
-      "version": "3.3.0",
+      "version": "3.3.2",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0",
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
         "axios": "0.24.0"
       }
     },
     "packages/beacon-transport-postmessage": {
       "name": "@airgap/beacon-transport-postmessage",
-      "version": "3.3.0",
+      "version": "3.3.2",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
       }
     },
     "packages/beacon-types": {
       "name": "@airgap/beacon-types",
-      "version": "3.3.0",
+      "version": "3.3.2",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "0.0.163"
@@ -15802,18 +15858,20 @@
     },
     "packages/beacon-ui": {
       "name": "@airgap/beacon-ui",
-      "version": "3.3.0",
+      "version": "3.3.2",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0",
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
       }
     },
     "packages/beacon-utils": {
       "name": "@airgap/beacon-utils",
-      "version": "3.3.0",
+      "version": "3.3.2",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@stablelib/nacl": "^1.0.3",
@@ -15824,12 +15882,12 @@
     },
     "packages/beacon-wallet": {
       "name": "@airgap/beacon-wallet",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-matrix": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2"
       }
     }
   },
@@ -15837,29 +15895,29 @@
     "@airgap/beacon-blockchain-substrate": {
       "version": "file:packages/beacon-blockchain-substrate",
       "requires": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "@airgap/beacon-blockchain-tezos": {
       "version": "file:packages/beacon-blockchain-tezos",
       "requires": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "@airgap/beacon-blockchain-tezos-sapling": {
       "version": "file:packages/beacon-blockchain-tezos-sapling",
       "requires": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0"
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2"
       }
     },
     "@airgap/beacon-core": {
       "version": "file:packages/beacon-core",
       "requires": {
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
         "@stablelib/ed25519": "^1.0.3",
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/utf8": "^1.0.1",
@@ -15870,46 +15928,71 @@
     "@airgap/beacon-dapp": {
       "version": "file:packages/beacon-dapp",
       "requires": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-matrix": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0",
-        "@airgap/beacon-ui": "^3.3.0",
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2",
         "qrcode-generator": "1.4.4"
       }
     },
-    "@airgap/beacon-transport-matrix": {
-      "version": "file:packages/beacon-transport-matrix",
+    "@airgap/beacon-sdk": {
+      "version": "file:packages/beacon-sdk",
       "requires": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0",
+        "@airgap/beacon-blockchain-substrate": "^3.3.2",
+        "@airgap/beacon-blockchain-tezos": "^3.3.2",
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-dapp": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-ui": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
+        "@airgap/beacon-wallet": "^3.3.2"
+      }
+    },
+    "@airgap/beacon-transport-matrix": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.3.2.tgz",
+      "integrity": "sha512-eE6UWuPQus8Z1yG6PpmaDCfiKjtfw0lJtw+KL4qvEsKDzJvhON0q2Wbr8swGxx6KaznA3U8auKg6vZFsDjCViw==",
+      "requires": {
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2",
         "axios": "0.24.0"
       }
     },
     "@airgap/beacon-transport-postmessage": {
-      "version": "file:packages/beacon-transport-postmessage",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.3.2.tgz",
+      "integrity": "sha512-STgr1fRmIWiUeGWTMhFXzYOvcOnLkEtmREidJvz5Lmts4TKgF6diRPDZa510XnuQoGsyZFnhHq/CQaLY53PfjQ==",
       "requires": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
       }
     },
     "@airgap/beacon-types": {
-      "version": "file:packages/beacon-types",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.3.2.tgz",
+      "integrity": "sha512-U4CM2eF04bAG+OGK9SiA32aVVkWBY/CuWfqhOX0T6vI7eRvK2Fc5tmGMp+HBqORBkb5ljPac9T47YUv8Wy/q2w==",
       "requires": {
         "@types/chrome": "0.0.163"
       }
     },
     "@airgap/beacon-ui": {
-      "version": "file:packages/beacon-ui",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.3.2.tgz",
+      "integrity": "sha512-V9gGZyfsTMIUe3ES10Uls51fp+7B13edPR970Fa4BoZxo6tyL8fPk1dD6plu/pJz2JxUZofpSinDYxW1iquAew==",
       "requires": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0",
-        "@airgap/beacon-types": "^3.3.0",
-        "@airgap/beacon-utils": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2",
+        "@airgap/beacon-types": "^3.3.2",
+        "@airgap/beacon-utils": "^3.3.2"
       }
     },
     "@airgap/beacon-utils": {
-      "version": "file:packages/beacon-utils",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.3.2.tgz",
+      "integrity": "sha512-nKK5FzluJfX7hgsq+uDeDlUip206G1OkvbvVSBXB4RppBHeg5ApHTvE8+0CMjvas20XMNdosnU5pFed3n4kF4Q==",
       "requires": {
         "@stablelib/nacl": "^1.0.3",
         "@stablelib/random": "^1.0.2",
@@ -15920,9 +16003,9 @@
     "@airgap/beacon-wallet": {
       "version": "file:packages/beacon-wallet",
       "requires": {
-        "@airgap/beacon-core": "^3.3.0",
-        "@airgap/beacon-transport-matrix": "^3.3.0",
-        "@airgap/beacon-transport-postmessage": "^3.3.0"
+        "@airgap/beacon-core": "^3.3.2",
+        "@airgap/beacon-transport-matrix": "^3.3.2",
+        "@airgap/beacon-transport-postmessage": "^3.3.2"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "dist/esm/index.js",
   "unpkg": "dist/walletbeacon.min.js",
   "types": "dist/esm/index.d.ts",
+  "workspaces": ["packages/*"],
   "keywords": [
     "airgap",
     "beacon",


### PR DESCRIPTION
## Summary
1. Use [NPM workspaces](https://docs.npmjs.com/cli/v9/using-npm/workspaces) instead of manually creating symbolic links.
2. Fixes the dependency versions in the `package-lock.json` from "^3.3.0" -> "^3.3.2"

From the NPM docs.
> This set of features makes up for a much more streamlined workflow handling linked packages from the local file system. Automating the linking process as part of npm install and avoiding manually having to use npm link in order to add references to packages that should be symlinked into the current node_modules folder.

## Testing
- Ran unit tests and build successfully.
