### PR TITLE
revert: temporarily remove Exodus mobile wallet

### DIFF
--- a/scripts/blockchains/tezos.ts
+++ b/scripts/blockchains/tezos.ts
@@ -164,15 +164,15 @@ export const tezosIosList: App[] = [
     deepLink: 'umami://',
     universalLink: 'https://umamiwallet.com/'
   },
-  {
-    key: 'exodus_mobile',
-    name: 'Exodus Mobile',
-    shortName: 'Exodus Mobile',
-    color: '',
-    logo: 'exodus.svg',
-    deepLink: 'exodus://',
-    universalLink:'https://www.exodus.com/'
-  },
+  // {
+  //   key: 'exodus_mobile',
+  //   name: 'Exodus Mobile',
+  //   shortName: 'Exodus Mobile',
+  //   color: '',
+  //   logo: 'exodus.svg',
+  //   deepLink: 'exodus://tzip10',
+  //   universalLink:'https://www.exodus.com/'
+  // },
   // {
   //   name: 'Galleon',
   //   shortName: 'Galleon',


### PR DESCRIPTION
The Exodus mobile wallet with Beacon support has not yet been released and needs to be temporarily removed to assure no one attempts to use it.