### PR TITLE
Add Marigold beacon node to default servers

### DIFF
--- a/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
+++ b/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
@@ -50,7 +50,8 @@ const REGIONS_AND_SERVERS: NodeDistributions = {
     'beacon-node-1.hope-2.papers.tech',
     'beacon-node-1.hope-3.papers.tech',
     'beacon-node-1.hope-4.papers.tech',
-    'beacon-node-1.hope-5.papers.tech'
+    'beacon-node-1.hope-5.papers.tech',
+    'beacon-node-1.marigold.dev'
   ]
 }
 


### PR DESCRIPTION
We've been running a beacon node from Marigold for a while and after discussing on Tezos slack with @AndreasGassmann it seems like there's no security blocker for putting it in the default servers list.

cc @cyrilevos @oteku