### PR TITLE
feat: added reactivity to window resize

### DIFF
--- a/packages/beacon-ui/src/components/top-wallets/index.tsx
+++ b/packages/beacon-ui/src/components/top-wallets/index.tsx
@@ -19,6 +19,17 @@ const TopWallets: Component<TopWalletsProps> = (props: TopWalletsProps) => {
   const [isMobile, setIsMobile] = createSignal(checkOS)
   const [windowWidth, setWindowWidth] = createSignal(window.innerWidth)
 
+  const debounce = (fun: Function, delay: number) => {
+    let timerId: NodeJS.Timeout
+
+    return (...args: any[]) => {
+      clearTimeout(timerId)
+      timerId = setTimeout(() => fun(...args), delay)
+    }
+  }
+
+  const debouncedSetWindowWidth = debounce(setWindowWidth, 200)
+
   const updateIsMobile = (isMobileWidth: boolean) => {
     // to avoid unwanted side effects (because of the OR condition), I always reset the value without checking the previous state
     setIsMobile(isMobileWidth || checkOS)
@@ -31,7 +42,7 @@ const TopWallets: Component<TopWalletsProps> = (props: TopWalletsProps) => {
   // Update the windowWidth signal when the window resizes
   createEffect(() => {
     const handleResize = () => {
-      setWindowWidth(window.innerWidth)
+      debouncedSetWindowWidth(window.innerWidth)
     }
 
     window.addEventListener('resize', handleResize)


### PR DESCRIPTION
Hi @jsamol,
I added reactivity to the modal, so that at each window resize we can check if we have gone beyond the 800px limit.
The isMobile flag is now a state (in solidJS a signal) initialised with the output of a regex match with `navigator.userAgent`
As you can tell by taking a look at the code, I avoided updated the state with the previous one because that would generate a lot of side effects.
In short:

- base case: (prevState = checkOs) => prevState || isMobileState
- 1: (prevState = checkOs  ||  isMobileState) => prevState || isMobileState 
and so on...

In any case, waiting for your feedback.
Isacco