### PR TITLE
fix: clear session

### DIFF
--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -174,7 +174,6 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     }
 
     if (this.activeAccount) {
-      await this.closeSessions()
       await this.openSession()
     }
 
@@ -602,6 +601,13 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     const { approval } = await signClient.connect(connectParams)
     const session = await approval()
 
+    // if I have successfully opened a session and I already have one opened
+    if(session && this.session) {
+      await this.closeSessions() // close the previous session
+    } 
+
+    // I still need this check in the event the user abort the sync process on the wallet side
+    // but I already have a connection set
     this.session = this.session ?? (session as SessionTypes.Struct)
     this.validateReceivedNamespace(permissionScopeParams, this.session.namespaces)
 

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -606,8 +606,8 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       await this.closeSessions() // close the previous session
     } 
 
-    // I still need this check in the event the user abort the sync process on the wallet side
-    // but I already have a connection set
+    // I still need this check in the event the user aborts the sync process on the wallet side
+    // but there is already a connection set
     this.session = this.session ?? (session as SessionTypes.Struct)
     this.validateReceivedNamespace(permissionScopeParams, this.session.namespaces)
 

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -602,9 +602,9 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     const session = await approval()
 
     // if I have successfully opened a session and I already have one opened
-    if(session && this.session) {
+    if (session && this.session) {
       await this.closeSessions() // close the previous session
-    } 
+    }
 
     // I still need this check in the event the user aborts the sync process on the wallet side
     // but there is already a connection set


### PR DESCRIPTION
Fix sessions not overlapping.
The code that handled this logic treated the openSession and closeSession separately.
This caused a side effect whenever a user tried to abort a new sync request meanwhile the DApp already had a valid session set.