### PR TITLE
fix: added error modal

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -660,8 +660,8 @@ export class DAppClient extends Client {
     if (elements?.includes('alert')) {
       // if the sync was aborted from the wallet side
       this._initPromise = undefined
-      // by dispatching two opposite events (one closes the alert the other one closes it)
-      // triggers some sort of race condition in the UI render cycle
+      // by dispatching two opposite events (one closes the alert the other one opens it)
+      // it triggers some sort of race condition in the UI render cycle
       setTimeout(async () => await this.events.emit(BeaconEvent.NO_PERMISSIONS), 1000)
     }
   }

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -655,12 +655,15 @@ export class DAppClient extends Client {
   }
 
   public async hideUI(elements?: ('alert' | 'toast')[]): Promise<void> {
-    if (elements?.includes('alert')) {
-      // if the sync was aborted from the wallet side or the alert is closed we need to cancel the promise
-      this._initPromise = undefined
-    }
-
     await this.events.emit(BeaconEvent.HIDE_UI, elements)
+
+    if (elements?.includes('alert')) {
+      // if the sync was aborted from the wallet side
+      this._initPromise = undefined
+      // by dispatching two opposite events (one closes the alert the other one closes it)
+      // triggers some sort of race condition in the UI render cycle
+      setTimeout(async () => await this.events.emit(BeaconEvent.NO_PERMISSIONS), 1000)
+    }
   }
 
   /**


### PR DESCRIPTION
This PR should solve "Rejection of operation request with prepare delay will not show an aborted error"
I haven't used the "PERMISSION_REQUEST_ERROR" toast, because during the very first initialisation phase `this.getWalletInfo()` won't return anything and therefore the toast message will appear broken.