### PR TITLE
fix: removed ui reset onError

### DIFF
--- a/examples/dapp.html
+++ b/examples/dapp.html
@@ -515,9 +515,7 @@
       document.getElementById('sendToSelfWithPrepare').addEventListener('click', () => {
         client.showPrepare()
         setTimeout(() => {
-          sendToSelf().catch((e) => {
-            client.hideUI()
-          })
+          sendToSelf()
         }, 2000)
       })
 


### PR DESCRIPTION
This PR should fix "Rejection of operation request with prepare delay will not show an aborted error"