### PR TITLE
fix: computations warning

### DIFF
--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -183,7 +183,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
     // Shadow root
     const shadowRootEl = document.createElement('div')
     if (document.getElementById('beacon-alert-wrapper')) {
-      (document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
+      ;(document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
     }
     shadowRootEl.setAttribute('id', 'beacon-alert-wrapper')
     shadowRootEl.style.height = '0px'
@@ -335,40 +335,44 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
     const [isMobile, setIsMobile] = createSignal(_isMobileOS)
     const [windowWidth, setWindowWidth] = createSignal(window.innerWidth)
 
-    const debounce = (fun: Function, delay: number) => {
-      let timerId: NodeJS.Timeout
+    const AlertResize = () => {
+      const debounce = (fun: Function, delay: number) => {
+        let timerId: NodeJS.Timeout
 
-      return (...args: any[]) => {
-        clearTimeout(timerId)
-        timerId = setTimeout(() => fun(...args), delay)
-      }
-    }
-
-    const debouncedSetWindowWidth = debounce(setWindowWidth, 200)
-
-    const updateIsMobile = (isMobileWidth: boolean) => {
-      // to avoid unwanted side effects (because of the OR condition), I always reset the value without checking the previous state
-      setWalletList(createWalletList())
-      setIsMobile(isMobileWidth || _isMobileOS)
-    }
-
-    createEffect(() => {
-      updateIsMobile(windowWidth() <= 800)
-    })
-
-    // Update the windowWidth signal when the window resizes
-    createEffect(() => {
-      const handleResize = () => {
-        debouncedSetWindowWidth(window.innerWidth)
+        return (...args: any[]) => {
+          clearTimeout(timerId)
+          timerId = setTimeout(() => fun(...args), delay)
+        }
       }
 
-      window.addEventListener('resize', handleResize)
+      const debouncedSetWindowWidth = debounce(setWindowWidth, 200)
 
-      // Unsubscribe from the event when the component unmounts
-      onCleanup(() => {
-        window.removeEventListener('resize', handleResize)
+      const updateIsMobile = (isMobileWidth: boolean) => {
+        // to avoid unwanted side effects (because of the OR condition), I always reset the value without checking the previous state
+        setWalletList(createWalletList())
+        setIsMobile(isMobileWidth || _isMobileOS)
+      }
+
+      createEffect(() => {
+        updateIsMobile(windowWidth() <= 800)
       })
-    })
+
+      // Update the windowWidth signal when the window resizes
+      createEffect(() => {
+        const handleResize = () => {
+          debouncedSetWindowWidth(window.innerWidth)
+        }
+
+        window.addEventListener('resize', handleResize)
+
+        // Unsubscribe from the event when the component unmounts
+        onCleanup(() => {
+          window.removeEventListener('resize', handleResize)
+        })
+      })
+
+      return <></>
+    }
 
     const handleClickShowMoreContent = () => {
       analytics()?.track('click', 'ui', 'show more wallets')
@@ -463,7 +467,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
           }
         }
         setIsLoading(false)
-      } else if (wallet?.types.includes('ios') && _isMobileOS) { 
+      } else if (wallet?.types.includes('ios') && _isMobileOS) {
         setCodeQR('')
 
         if (config.pairingPayload) {
@@ -570,6 +574,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
     dispose = render(
       () => (
         <div class={`theme__${colorMode}`}>
+          <AlertResize />
           {config.pairingPayload && (
             <Alert
               loading={isLoading()}


### PR DESCRIPTION
In SolidJS, computations and cleanups should be created within a component that is being rendered. 
However with our approach only whatever is inside the `dispose` function is actually called with the `render` method.
To resolve this warning, you can wrap your component in a `createRoot` or `render` function.