### PR TITLE
fix: web wallet no pairing choice modal

### DIFF
--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -789,7 +789,7 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
   }
   /**
    * @description Access the active network
-   * @error ActiveNetworkUnspecified thorwn when there are multiple Tezos netwroks in the session and none is set as the active one
+   * @error ActiveNetworkUnspecified thorwn when there are multiple Tezos networks in the session and none is set as the active one
    */
   getActiveNetwork() {
     if (!this.activeNetwork) {

--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -183,7 +183,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
     // Shadow root
     const shadowRootEl = document.createElement('div')
     if (document.getElementById('beacon-alert-wrapper')) {
-      ;(document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
+      (document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
     }
     shadowRootEl.setAttribute('id', 'beacon-alert-wrapper')
     shadowRootEl.style.height = '0px'

--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -33,6 +33,7 @@ import {
   arrangeTopWallets,
   MergedWallet,
   mergeWallets,
+  OSLink,
   parseWallets,
   Wallet
 } from 'src/utils/wallets'
@@ -389,6 +390,41 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
       if (config.closeButtonCallback) config.closeButtonCallback()
     }
 
+    const handleNewTab = async (config: AlertConfig, wallet?: MergedWallet) => {
+      if(!wallet) {
+        return
+      }
+
+      if (config.pairingPayload) {
+        // Noopener feature parameter cannot be used, because Chrome will open
+        // about:blank#blocked instead and it will no longer work.
+        const newTab = window.open('', '_blank')
+
+        if (newTab) {
+          newTab.opener = null
+        }
+
+        let link = ''
+
+        if (wallet.supportedInteractionStandards?.includes('wallet_connect')) {
+          const uri = (await wcPayload)?.uri
+          if (uri) {
+            link = `${wallet.links[OSLink.WEB]}/wc?uri=${encodeURIComponent(uri)}`
+          }
+        } else {
+          const serializer = new Serializer()
+          const code = await serializer.serialize(await p2pPayload)
+          link = getTzip10Link(wallet.links[OSLink.WEB], code)
+        }
+
+        if (newTab) {
+          newTab.location.href = link
+        } else {
+          window.open(link, '_blank', 'noopener')
+        }
+      }
+    }
+
     const handleClickWallet = async (id: string) => {
       if (isLoading()) return
 
@@ -409,35 +445,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
           wallet?.types.includes('ios')
         )
       ) {
-        if (config.pairingPayload) {
-          // Noopener feature parameter cannot be used, because Chrome will open
-          // about:blank#blocked instead and it will no longer work.
-          const newTab = window.open('', '_blank')
-
-          if (newTab) {
-            newTab.opener = null
-          }
-
-          let link = ''
-
-          if (wallet.supportedInteractionStandards?.includes('wallet_connect')) {
-            const uri = (await wcPayload)?.uri
-            if (uri) {
-              link = `${wallet.link}/wc?uri=${encodeURIComponent(uri)}`
-            }
-          } else {
-            const serializer = new Serializer()
-            const code = await serializer.serialize(await p2pPayload)
-            link = getTzip10Link(wallet.link, code)
-          }
-
-          if (newTab) {
-            newTab.location.href = link
-          } else {
-            window.open(link, '_blank', 'noopener')
-          }
-        }
-
+        handleNewTab(config, wallet)
         return
       }
 
@@ -479,7 +487,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
               ? wallet.deepLink
               : isAndroid(window)
               ? 'tezos://'
-              : wallet.link,
+              : wallet.links[OSLink.IOS],
             code
           )
 
@@ -541,7 +549,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
       analytics()?.track('click', 'ui', 'install extension', { key: currentWallet()?.key })
 
       setShowMoreContent(false)
-      window.open(currentWallet()?.link || '', '_blank', 'noopener')
+      window.open(currentWallet()?.links[OSLink.EXTENSION] || '', '_blank', 'noopener')
     }
 
     const handleClickOpenDesktopApp = async () => {
@@ -560,7 +568,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
       analytics()?.track('click', 'ui', 'download desktop', { key: currentWallet()?.key })
 
       setShowMoreContent(false)
-      window.open(currentWallet()?.link || '', '_blank', 'noopener')
+      window.open(currentWallet()?.links[OSLink.DESKTOP] || '', '_blank', 'noopener')
     }
 
     const hasExtension = () =>
@@ -610,14 +618,14 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
                       {!isMobile() && isOnline && currentWallet()?.types.includes('web') && (
                         <Info
                           border
-                          title={'Open Wallet in a new Tab'}
+                          title={'Open wallet in a new tab'}
                           description={`Please connect below to use ${currentWallet()?.name}`}
                           buttons={[
                             {
                               label: 'Connect now',
                               type: 'primary',
                               onClick: () =>
-                                window.open(currentWallet()?.link, '_blank', 'noopener')
+                              handleNewTab(config, currentWallet())
                             }
                           ]}
                         />

--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -183,7 +183,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
     // Shadow root
     const shadowRootEl = document.createElement('div')
     if (document.getElementById('beacon-alert-wrapper')) {
-      (document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
+      ;(document.getElementById('beacon-alert-wrapper') as HTMLElement).remove()
     }
     shadowRootEl.setAttribute('id', 'beacon-alert-wrapper')
     shadowRootEl.style.height = '0px'
@@ -404,7 +404,14 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
         localStorage.setItem(StorageKey.LAST_SELECTED_WALLET, wallet.key)
       }
 
-      if (wallet?.types.includes('web')) {
+      if (
+        wallet?.types.includes('web') &&
+        !(
+          wallet?.types.includes('extension') ||
+          wallet?.types.includes('desktop') ||
+          wallet?.types.includes('ios')
+        )
+      ) {
         if (config.pairingPayload) {
           // Noopener feature parameter cannot be used, because Chrome will open
           // about:blank#blocked instead and it will no longer work.
@@ -463,7 +470,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
           }
         }
         setIsLoading(false)
-      } else if (wallet?.types.includes('ios') && _isMobileOS) { 
+      } else if (wallet?.types.includes('ios') && _isMobileOS) {
         setCodeQR('')
 
         if (config.pairingPayload) {


### PR DESCRIPTION
This should fix #572
In order to make other pairing options appear (i.e "Pair with mobile"), you still need to add an object entry in one or more lists inside the `tezos.ts` file