### PR TITLE
fix: duckduckgo browser pairing blocked

### DIFF
--- a/packages/beacon-ui/src/utils/platform.ts
+++ b/packages/beacon-ui/src/utils/platform.ts
@@ -33,9 +33,11 @@ const isIpad = (win: Window): boolean => {
   return false
 }
 
-export const isIOS = (win: Window): boolean => testUserAgent(win, /iPhone|iPod/i) || isIpad(win)
+export const isPrivacyBrowser = (win: Window): boolean => testUserAgent(win, /Mobile DuckDuckGo/i)
 
-export const isAndroid = (win: Window): boolean => testUserAgent(win, /android|sink/i)
+export const isIOS = (win: Window): boolean => isPrivacyBrowser(win) || testUserAgent(win, /iPhone|iPod|Mobile DuckDuckGo/i) || isIpad(win)
+
+export const isAndroid = (win: Window): boolean => !isPrivacyBrowser(win) && testUserAgent(win, /android|sink/i)
 
 export const isTwBrowser = (win: Window): boolean => win && (win as any).ethereum?.isTrust == true
 


### PR DESCRIPTION
This should solve #585 
I added `DuckDuckGO Mobile` to the IOS group because it seems it has a built-in popup blocker like Safari and thus the code should behave the same.