### PR TITLE
Fix/stuck state

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -183,6 +183,8 @@ export class DAppClient extends Client {
 
   private _initPromise: Promise<TransportType> | undefined
 
+  private isInitPending: boolean = false
+
   private readonly activeAccountLoaded: Promise<AccountInfo | undefined>
 
   private readonly appMetadataManager: AppMetadataManager
@@ -1769,9 +1771,16 @@ export class DAppClient extends Client {
   ) {
     const messageId = await generateGUID()
 
+    if (!(await this.getActiveAccount()) && this._initPromise && this.isInitPending) {
+      this._initPromise = undefined
+      this.hideUI(['toast'])
+    }
+
     logger.time(true, messageId)
     logger.log('makeRequest', 'starting')
+    this.isInitPending = true
     await this.init()
+    this.isInitPending = false
     logger.timeLog(messageId, 'init done')
     logger.log('makeRequest', 'after init')
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -1772,10 +1772,7 @@ export class DAppClient extends Client {
     const messageId = await generateGUID()
 
     if (this._initPromise && this.isInitPending) {
-      await Promise.all([
-        this.postMessageTransport?.disconnect(),
-        this.walletConnectTransport?.disconnect()
-      ])
+      await this.destroy()
       this._initPromise = undefined
       this.hideUI(['toast'])
     }

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -1771,7 +1771,11 @@ export class DAppClient extends Client {
   ) {
     const messageId = await generateGUID()
 
-    if (!(await this.getActiveAccount()) && this._initPromise && this.isInitPending) {
+    if (this._initPromise && this.isInitPending) {
+      await Promise.all([
+        this.postMessageTransport?.disconnect(),
+        this.walletConnectTransport?.disconnect()
+      ])
       this._initPromise = undefined
       this.hideUI(['toast'])
     }

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -1772,7 +1772,10 @@ export class DAppClient extends Client {
     const messageId = await generateGUID()
 
     if (this._initPromise && this.isInitPending) {
-      await this.destroy()
+      await Promise.all([
+        this.postMessageTransport?.disconnect(),
+        this.walletConnectTransport?.disconnect()
+      ])
       this._initPromise = undefined
       this.hideUI(['toast'])
     }
@@ -1902,10 +1905,21 @@ export class DAppClient extends Client {
     message: U
     connectionInfo: ConnectionContext
   }> {
+    if (this._initPromise && this.isInitPending) {
+      await Promise.all([
+        this.postMessageTransport?.disconnect(),
+        this.walletConnectTransport?.disconnect()
+      ])
+      this._initPromise = undefined
+      this.hideUI(['toast'])
+    }
+
     const messageId = await generateGUID()
     logger.time(true, messageId)
     logger.log('makeRequest', 'starting')
+    this.isInitPending = true
     await this.init()
+    this.isInitPending = false
     logger.timeLog('makeRequest', messageId, 'init done')
     logger.log('makeRequest', 'after init')
 


### PR DESCRIPTION
This PR addresses a bug which caused beacon to enter a stuck state if a users closed a tab without approving or rejecting a sync approval
This PR is also related to #664