### PR TITLE
fix: lazy connection for WC

### DIFF
--- a/packages/beacon-ui/src/components/pair-other/pair-other.tsx
+++ b/packages/beacon-ui/src/components/pair-other/pair-other.tsx
@@ -8,7 +8,7 @@ import { Serializer } from '@airgap/beacon-core'
 export interface PairOtherProps {
   walletList: MergedWallet[]
   p2pPayload: Promise<P2PPairingRequest> | undefined
-  wcPayload: Promise<WalletConnectPairingRequest> | undefined
+  wcPayload: () => Promise<WalletConnectPairingRequest>
   onClickLearnMore: () => void
 }
 
@@ -34,7 +34,8 @@ const PairOther: Component<PairOtherProps> = (props: PairOtherProps) => {
         setQrData(codeQR)
       })
     } else if (state === 'walletconnect' && !!props.wcPayload) {
-      props.wcPayload
+      props
+        .wcPayload()
         .then((payload) => {
           setQrData(payload.uri)
         })

--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -142,7 +142,9 @@ const closeAlerts = async (): Promise<void> =>
 const openAlert = async (config: AlertConfig): Promise<string> => {
   setIsLoading(false)
   const p2pPayload = config.pairingPayload?.p2pSyncCode()
-  const wcPayload = config.pairingPayload?.walletConnectSyncCode()
+  const wcPayload = config.pairingPayload
+    ? config.pairingPayload.walletConnectSyncCode
+    : async () => ({ uri: null })
   const isOnline = navigator.onLine
 
   setAnalytics(config.analytics)
@@ -447,7 +449,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
       let link = ''
 
       if (wallet.supportedInteractionStandards?.includes('wallet_connect')) {
-        const uri = (await wcPayload)?.uri ?? ''
+        const uri = (await wcPayload())?.uri ?? ''
         if (!!uri.length) {
           link = `${wallet.links[OSLink.WEB]}/wc?uri=${encodeURIComponent(uri)}`
         } else {
@@ -537,7 +539,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
       }
 
       if (wallet && wallet.supportedInteractionStandards?.includes('wallet_connect')) {
-        const uri = (await wcPayload)?.uri ?? ''
+        const uri = (await wcPayload())?.uri ?? ''
 
         if (!!uri.length) {
           if (_isMobileOS && wallet.types.includes('ios') && wallet.types.length === 1) {
@@ -853,7 +855,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
                                 if (
                                   wallet.supportedInteractionStandards?.includes('wallet_connect')
                                 ) {
-                                  syncCode = (await wcPayload)?.uri ?? ''
+                                  syncCode = (await wcPayload())?.uri ?? ''
                                 } else {
                                   syncCode = await new Serializer().serialize(await p2pPayload)
                                 }
@@ -895,7 +897,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
                         walletList={walletList()}
                         onClickLearnMore={handleClickLearnMore}
                         p2pPayload={p2pPayload}
-                        wcPayload={wcPayload}
+                        wcPayload={wcPayload as () => Promise<WalletConnectPairingRequest>}
                       ></PairOther>
                     </div>
                   )}


### PR DESCRIPTION
Previously we connected eagerly to all the transports because we need a URI to generate a sync QR code.
This works really well for P2P transport, otherwise there's gonna be a visible delay before the QR gets displayed.
Unfortunately whenever we initialize a WC instance, internally an expirer property set to 5 minutes is also load up.
What this property does is to invalidate a pairing in the event a sync doesn't happen within the scheduled time.
Therefore, the proposed change is to connect through walletconnect lazily to avoid setting up such counter for wallets on a different transport than WC.