### PR TITLE
fix: WC bugs

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -668,6 +668,7 @@ export class DAppClient extends Client {
                   // p2pTransport.disconnect(), do not abort connection manually
                   walletConnectTransport.disconnect()
                 ])
+                this._activeAccount.isResolved() && this.clearActiveAccount()
                 this._initPromise = undefined
               },
               disclaimerText: this.disclaimerText,


### PR DESCRIPTION
1. This PR addresses a potential bug that appears only when 2 or more tabs are open, and all of them have a paring modal open.
In this scenario when a tab successfully pairs with a wallet, the others also correctly sync thanks to broadcast channel. However, beacon enters a broken state when closing all the open alerts because, in the tabs that never concluded the sync, they still have a pending proposal.
2. WC's ping gets dropped after a delay oft 30s. Added interval to generate a new one after expiration.
