### PR TITLE
[Feat] Tzip 28 support with build fixed

### DIFF
--- a/examples/abstracted-account.html
+++ b/examples/abstracted-account.html
@@ -412,8 +412,6 @@
 
               // Send response back to DApp
               client.respond(response)
-            } else if (message.type === beacon.BeaconMessageType.ProofOfEventChallengeRecorded) {
-              console.log('Proof of event challenge has been recorded')
             } else if (message.type === beacon.BeaconMessageType.ProofOfEventChallengeRequest) {
               const isAccepted = window.confirm(
                 'Do you want to accept the Proof Of Event Challenge ?'

--- a/examples/dapp.html
+++ b/examples/dapp.html
@@ -400,14 +400,15 @@
           })
       }
 
-<<<<<<< HEAD
       // disconnect
       const disconnect = () => {
         client
           .disconnect()
           .then(() => console.log('disconnected.'))
           .catch((err) => console.error(err.message))
-=======
+
+      }
+
       const requestSimulatedProofOfEventChallenge = () => {
         client
           .requestSimulatedProofOfEventChallenge({
@@ -419,7 +420,6 @@
           .catch((error) => {
             console.log('error during Proof Of Event Challenge', error)
           })
->>>>>>> 264e2bd3 (feat: Added the support for tzip-28)
       }
 
       document.getElementById('connect').addEventListener('click', () => {

--- a/examples/dapp.html
+++ b/examples/dapp.html
@@ -62,6 +62,10 @@
       Request Proof Of Event Challenge
     </button>
     <br /><br />
+    <button id="requestSimulatedProofOfEventChallenge" disabled style="opacity: 0.5">
+      Request Simulated Proof Of Event Challenge
+    </button>
+    <br /><br />
     <button id="sendToSelf">Send 1 mutez to myself</button>
     <br /><br />
     <button id="sendToSelfWithPrepare">Send 1 mutez to myself (with 1s prepare delay)</button>
@@ -258,6 +262,10 @@
             btn = document.getElementById('requestProofOfEventChallenge')
             btn.style.opacity = '1'
             btn.disabled = false
+
+            btn = document.getElementById('requestSimulatedProofOfEventChallenge')
+            btn.style.opacity = '1'
+            btn.disabled = false
           } else {
             document.getElementById('activeAccount').innerText = ''
             document.getElementById('activeAccountNetwork').innerText = ''
@@ -392,12 +400,26 @@
           })
       }
 
+<<<<<<< HEAD
       // disconnect
       const disconnect = () => {
         client
           .disconnect()
           .then(() => console.log('disconnected.'))
           .catch((err) => console.error(err.message))
+=======
+      const requestSimulatedProofOfEventChallenge = () => {
+        client
+          .requestSimulatedProofOfEventChallenge({
+            payload: JSON.stringify({ timestamp: Date.now() })
+          })
+          .then((response) => {
+            console.log('SimulatedProofOfEventChallenge response', response)
+          })
+          .catch((error) => {
+            console.log('error during Proof Of Event Challenge', error)
+          })
+>>>>>>> 264e2bd3 (feat: Added the support for tzip-28)
       }
 
       document.getElementById('connect').addEventListener('click', () => {
@@ -440,6 +462,13 @@
       document.getElementById('requestProofOfEventChallenge').addEventListener('click', () => {
         requestProofOfEventChallenge()
       })
+
+      // Add event listener to the button
+      document
+        .getElementById('requestSimulatedProofOfEventChallenge')
+        .addEventListener('click', () => {
+          requestSimulatedProofOfEventChallenge()
+        })
 
       // Add event listener to the button
       document.getElementById('reset').addEventListener('click', () => {

--- a/packages/beacon-dapp/src/beacon-message-events.ts
+++ b/packages/beacon-dapp/src/beacon-message-events.ts
@@ -34,6 +34,16 @@ export const messageEvents: {
     success: BeaconEvent.UNKNOWN,
     error: BeaconEvent.UNKNOWN
   },
+  [BeaconMessageType.SimulatedProofOfEventChallengeRequest]: {
+    sent: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT,
+    success: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS,
+    error: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR
+  },
+  [BeaconMessageType.SimulatedProofOfEventChallengeResponse]: {
+    sent: BeaconEvent.UNKNOWN,
+    success: BeaconEvent.UNKNOWN,
+    error: BeaconEvent.UNKNOWN
+  },
   [BeaconMessageType.OperationRequest]: {
     sent: BeaconEvent.OPERATION_REQUEST_SENT,
     success: BeaconEvent.OPERATION_REQUEST_SUCCESS,

--- a/packages/beacon-dapp/src/beacon-message-events.ts
+++ b/packages/beacon-dapp/src/beacon-message-events.ts
@@ -35,9 +35,9 @@ export const messageEvents: {
     error: BeaconEvent.UNKNOWN
   },
   [BeaconMessageType.SimulatedProofOfEventChallengeRequest]: {
-    sent: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT,
-    success: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS,
-    error: BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR
+    sent: BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT,
+    success: BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS,
+    error: BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR
   },
   [BeaconMessageType.SimulatedProofOfEventChallengeResponse]: {
     sent: BeaconEvent.UNKNOWN,

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -950,7 +950,8 @@ export class DAppClient extends Client {
     if (
       [
         BeaconMessageType.PermissionRequest,
-        BeaconMessageType.ProofOfEventChallengeRequest
+        BeaconMessageType.ProofOfEventChallengeRequest,
+        BeaconMessageType.SimulatedProofOfEventChallengeRequest
       ].includes(type)
     ) {
       return true

--- a/packages/beacon-dapp/src/events.ts
+++ b/packages/beacon-dapp/src/events.ts
@@ -27,7 +27,9 @@ import {
   WalletInfo,
   ExtendedWalletConnectPairingResponse,
   WalletConnectPairingRequest,
-  AnalyticsInterface
+  AnalyticsInterface,
+  ProofOfEventChallengeResponseOutput,
+  SimulatedProofOfEventChallengeResponseOutput
 } from '@airgap/beacon-types'
 import {
   UnknownBeaconError,
@@ -39,7 +41,6 @@ import {
 } from '@airgap/beacon-core'
 import { shortenString } from './utils/shorten-string'
 import { isMobile } from '@airgap/beacon-ui'
-import { ProofOfEventChallengeResponseOutput } from '@airgap/beacon-types'
 
 const logger = new Logger('BeaconEvents')
 
@@ -65,6 +66,9 @@ export enum BeaconEvent {
   PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT = 'PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT',
   PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS = 'PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS',
   PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR = 'PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR',
+  SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT = 'SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT',
+  SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS = 'SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS',
+  SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR = 'SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR',
   OPERATION_REQUEST_SENT = 'OPERATION_REQUEST_SENT',
   OPERATION_REQUEST_SUCCESS = 'OPERATION_REQUEST_SUCCESS',
   OPERATION_REQUEST_ERROR = 'OPERATION_REQUEST_ERROR',
@@ -130,6 +134,18 @@ export interface BeaconEventType {
     walletInfo: WalletInfo
   }
   [BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: {
+    errorResponse: ErrorResponse
+    walletInfo: WalletInfo
+  }
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT]: RequestSentInfo
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS]: {
+    account: AccountInfo
+    output: SimulatedProofOfEventChallengeResponseOutput
+    blockExplorer: BlockExplorer
+    connectionContext: ConnectionContext
+    walletInfo: WalletInfo
+  }
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: {
     errorResponse: ErrorResponse
     walletInfo: WalletInfo
   }
@@ -522,6 +538,25 @@ const showProofOfEventChallengeSuccessAlert = async (
   })
 }
 
+const showSimulatedProofOfEventChallengeSuccessAlert = async (
+  data: BeaconEventType[BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS]
+): Promise<void> => {
+  const { output } = data
+
+  await openToast({
+    body: `{{wallet}}\u00A0 has ${!output.errorMessage ? 'accepted' : 'refused'} the challenge`,
+    timer: SUCCESS_TIMER,
+    walletInfo: data.walletInfo,
+    state: 'finished',
+    actions: [
+      {
+        text: 'Operation list',
+        actionText: output.operationsList
+      }
+    ]
+  })
+}
+
 /**
  * Show an "Operation Broadcasted" alert
  *
@@ -682,6 +717,10 @@ export const defaultEventCallbacks: {
   [BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT]: showSentToast,
   [BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS]: showProofOfEventChallengeSuccessAlert,
   [BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: showErrorToast,
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT]: showSentToast,
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS]:
+    showSimulatedProofOfEventChallengeSuccessAlert,
+  [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: showErrorToast,
   [BeaconEvent.OPERATION_REQUEST_SENT]: showSentToast,
   [BeaconEvent.OPERATION_REQUEST_SUCCESS]: showOperationSuccessAlert,
   [BeaconEvent.OPERATION_REQUEST_ERROR]: showErrorToast,
@@ -730,6 +769,15 @@ export class BeaconEventHandler {
     ],
     [BeaconEvent.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: [
       defaultEventCallbacks.PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR
+    ],
+    [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT]: [
+      defaultEventCallbacks.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SENT
+    ],
+    [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS]: [
+      defaultEventCallbacks.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_SUCCESS
+    ],
+    [BeaconEvent.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR]: [
+      defaultEventCallbacks.SIMULATED_PROOF_OF_EVENT_CHALLENGE_REQUEST_ERROR
     ],
     [BeaconEvent.OPERATION_REQUEST_SENT]: [defaultEventCallbacks.OPERATION_REQUEST_SENT],
     [BeaconEvent.OPERATION_REQUEST_SUCCESS]: [defaultEventCallbacks.OPERATION_REQUEST_SUCCESS],

--- a/packages/beacon-types/src/index.ts
+++ b/packages/beacon-types/src/index.ts
@@ -6,6 +6,8 @@ import { AppMetadata } from './types/beacon/AppMetadata'
 import { PermissionRequest } from './types/beacon/messages/PermissionRequest'
 import { ProofOfEventChallengeRequest } from './types/beacon/messages/ProofOfEventChallengeRequest'
 import { ProofOfEventChallengeResponse } from './types/beacon/messages/ProofOfEventChallengeResponse'
+import { SimulatedProofOfEventChallengeRequest } from './types/beacon/messages/SimulatedProofOfEventChallengeRequest'
+import { SimulatedProofOfEventChallengeResponse } from './types/beacon/messages/SimulatedProofOfEventChallengeResponse'
 import { Network } from './types/beacon/Network'
 import { BeaconBaseMessage } from './types/beacon/BeaconBaseMessage'
 import { BeaconMessageType } from './types/beacon/BeaconMessageType'
@@ -52,6 +54,7 @@ import { ExtendedP2PPairingRequest, P2PPairingRequest } from './types/P2PPairing
 import { BeaconMessage } from './types/beacon/BeaconMessage'
 import { RequestPermissionInput } from './types/RequestPermissionInput'
 import { RequestProofOfEventChallengeInput } from './types/RequestProofOfEventChallengeInput'
+import { RequestSimulatedProofOfEventChallengeInput } from './types/RequestSimulatedProofOfEventChallengeInput'
 import { RequestSignPayloadInput } from './types/RequestSignPayloadInput'
 // import { RequestEncryptPayloadInput } from './types/RequestEncryptPayloadInput'
 import { RequestOperationInput } from './types/RequestOperationInput'
@@ -74,7 +77,8 @@ import {
   OperationResponseOutput,
   BroadcastResponseOutput,
   BeaconResponseOutputMessage,
-  ProofOfEventChallengeResponseOutput
+  ProofOfEventChallengeResponseOutput,
+  SimulatedProofOfEventChallengeResponseOutput
 } from './types/beacon/messages/BeaconResponseOutputMessage'
 import {
   PermissionRequestInput,
@@ -85,6 +89,7 @@ import {
   BeaconRequestInputMessage,
   IgnoredRequestInputProperties,
   ProofOfEventChallengeRequestInput
+  SimulatedProofOfEventChallengeRequestInput
 } from './types/beacon/messages/BeaconRequestInputMessage'
 import {
   PermissionRequestOutput,
@@ -93,7 +98,8 @@ import {
   OperationRequestOutput,
   BroadcastRequestOutput,
   BeaconRequestOutputMessage,
-  ProofOfEventChallengeRequestOutput
+  ProofOfEventChallengeRequestOutput,
+  SimulatedProofOfEventChallengeRequestOutput,
 } from './types/beacon/messages/BeaconRequestOutputMessage'
 import { PermissionInfo } from './types/PermissionInfo'
 import { ConnectionContext } from './types/ConnectionContext'
@@ -255,6 +261,7 @@ export {
   EncryptedExtensionMessage,
   RequestPermissionInput,
   RequestProofOfEventChallengeInput,
+  RequestSimulatedProofOfEventChallengeInput,
   RequestSignPayloadInput,
   // RequestEncryptPayloadInput,
   RequestOperationInput,
@@ -262,7 +269,9 @@ export {
   PermissionInfo,
   PermissionEntity,
   ProofOfEventChallengeRequest,
-  ProofOfEventChallengeResponse
+  ProofOfEventChallengeResponse,
+  SimulatedProofOfEventChallengeRequest,
+  SimulatedProofOfEventChallengeResponse
 }
 
 export {
@@ -275,6 +284,7 @@ export {
   ErrorResponseInput,
   PermissionResponseOutput,
   ProofOfEventChallengeResponseOutput,
+  SimulatedProofOfEventChallengeResponseOutput,
   SignPayloadResponseOutput,
   // EncryptPayloadResponseOutput,
   OperationResponseOutput,
@@ -282,12 +292,14 @@ export {
   PermissionRequestInput,
   SignPayloadRequestInput,
   ProofOfEventChallengeRequestInput,
+  SimulatedProofOfEventChallengeRequestInput,
   // EncryptPayloadRequestInput,
   OperationRequestInput,
   BroadcastRequestInput,
   PermissionRequestOutput,
   SignPayloadRequestOutput,
   ProofOfEventChallengeRequestOutput,
+  SimulatedProofOfEventChallengeRequestOutput,
   // EncryptPayloadRequestOutput,
   OperationRequestOutput,
   BroadcastRequestOutput,

--- a/packages/beacon-types/src/index.ts
+++ b/packages/beacon-types/src/index.ts
@@ -88,7 +88,7 @@ import {
   BroadcastRequestInput,
   BeaconRequestInputMessage,
   IgnoredRequestInputProperties,
-  ProofOfEventChallengeRequestInput
+  ProofOfEventChallengeRequestInput,
   SimulatedProofOfEventChallengeRequestInput
 } from './types/beacon/messages/BeaconRequestInputMessage'
 import {

--- a/packages/beacon-types/src/types/RequestSimulatedProofOfEventChallengeInput.ts
+++ b/packages/beacon-types/src/types/RequestSimulatedProofOfEventChallengeInput.ts
@@ -1,0 +1,7 @@
+/**
+ * @category DApp
+ */
+export interface RequestSimulatedProofOfEventChallengeInput {
+  /** A custom payload than should be emitted by the list of operations returned by the dapp*/
+  payload: string
+}

--- a/packages/beacon-types/src/types/beacon/BeaconMessage.ts
+++ b/packages/beacon-types/src/types/beacon/BeaconMessage.ts
@@ -14,6 +14,8 @@ import {
   ErrorResponse,
   ProofOfEventChallengeRequest,
   ProofOfEventChallengeResponse,
+  SimulatedProofOfEventChallengeRequest,
+  SimulatedProofOfEventChallengeResponse,
   ChangeAccountRequest
 } from '@airgap/beacon-types'
 
@@ -25,6 +27,8 @@ export type BeaconMessage =
   | PermissionResponse
   | ProofOfEventChallengeRequest
   | ProofOfEventChallengeResponse
+  | SimulatedProofOfEventChallengeRequest
+  | SimulatedProofOfEventChallengeResponse
   | OperationRequest
   | OperationResponse
   | SignPayloadRequest

--- a/packages/beacon-types/src/types/beacon/BeaconMessageType.ts
+++ b/packages/beacon-types/src/types/beacon/BeaconMessageType.ts
@@ -12,6 +12,8 @@ export enum BeaconMessageType {
   // EncryptPayloadResponse = 'encrypt_payload_response',
   ProofOfEventChallengeRequest = 'proof_of_event_challenge_request',
   ProofOfEventChallengeResponse = 'proof_of_event_challenge_response',
+  SimulatedProofOfEventChallengeRequest = 'simulated_proof_of_event_challenge_request',
+  SimulatedProofOfEventChallengeResponse = 'simulated_proof_of_event_challenge_response',
   OperationResponse = 'operation_response',
   BroadcastResponse = 'broadcast_response',
   Acknowledge = 'acknowledge',

--- a/packages/beacon-types/src/types/beacon/BeaconRequestMessage.ts
+++ b/packages/beacon-types/src/types/beacon/BeaconRequestMessage.ts
@@ -3,7 +3,8 @@ import {
   OperationRequest,
   SignPayloadRequest,
   BroadcastRequest,
-  ProofOfEventChallengeRequest
+  ProofOfEventChallengeRequest,
+  SimulatedProofOfEventChallengeRequest
   // EncryptPayloadRequest
 } from '@airgap/beacon-types'
 
@@ -17,3 +18,4 @@ export type BeaconRequestMessage =
   // | EncryptPayloadRequest
   | BroadcastRequest
   | ProofOfEventChallengeRequest
+  | SimulatedProofOfEventChallengeRequest

--- a/packages/beacon-types/src/types/beacon/messages/BeaconRequestInputMessage.ts
+++ b/packages/beacon-types/src/types/beacon/messages/BeaconRequestInputMessage.ts
@@ -4,6 +4,7 @@ import {
   OperationRequest,
   SignPayloadRequest,
   ProofOfEventChallengeRequest,
+  SimulatedProofOfEventChallengeRequest,
   // EncryptPayloadRequest,
   BroadcastRequest
 } from '@airgap/beacon-types'
@@ -25,6 +26,14 @@ export type PermissionRequestInput = Optional<PermissionRequest, IgnoredRequestI
  */
 export type ProofOfEventChallengeRequestInput = Optional<
   ProofOfEventChallengeRequest,
+  IgnoredRequestInputProperties
+>
+/**
+ * @internalapi
+ * @category DApp
+ */
+export type SimulatedProofOfEventChallengeRequestInput = Optional<
+  SimulatedProofOfEventChallengeRequest,
   IgnoredRequestInputProperties
 >
 /**
@@ -62,3 +71,4 @@ export type BeaconRequestInputMessage =
   | SignPayloadRequestInput
   | BroadcastRequestInput
   | ProofOfEventChallengeRequestInput
+  | SimulatedProofOfEventChallengeRequestInput

--- a/packages/beacon-types/src/types/beacon/messages/BeaconRequestOutputMessage.ts
+++ b/packages/beacon-types/src/types/beacon/messages/BeaconRequestOutputMessage.ts
@@ -1,4 +1,8 @@
-import { Optional, ProofOfEventChallengeRequest } from '@airgap/beacon-types'
+import {
+  Optional,
+  ProofOfEventChallengeRequest,
+  SimulatedProofOfEventChallengeRequest
+} from '@airgap/beacon-types'
 import {
   AppMetadata,
   PermissionRequest,
@@ -30,6 +34,14 @@ export type PermissionRequestOutput = Optional<PermissionRequest, IgnoredRequest
  */
 export type ProofOfEventChallengeRequestOutput = Optional<
   ProofOfEventChallengeRequest,
+  IgnoredRequestOutputProperties
+> &
+  ExtraResponseOutputProperties
+/**
+ * @category Wallet
+ */
+export type SimulatedProofOfEventChallengeRequestOutput = Optional<
+  SimulatedProofOfEventChallengeRequest,
   IgnoredRequestOutputProperties
 > &
   ExtraResponseOutputProperties
@@ -71,3 +83,4 @@ export type BeaconRequestOutputMessage =
   // | EncryptPayloadRequestOutput
   | BroadcastRequestOutput
   | ProofOfEventChallengeRequestOutput
+  | SimulatedProofOfEventChallengeRequestOutput

--- a/packages/beacon-types/src/types/beacon/messages/BeaconResponseInputMessage.ts
+++ b/packages/beacon-types/src/types/beacon/messages/BeaconResponseInputMessage.ts
@@ -1,4 +1,8 @@
-import { Optional, ProofOfEventChallengeResponse } from '@airgap/beacon-types'
+import {
+  Optional,
+  ProofOfEventChallengeResponse,
+  SimulatedProofOfEventChallengeResponse
+} from '@airgap/beacon-types'
 import {
   PermissionResponse,
   OperationResponse,
@@ -26,6 +30,13 @@ export type PermissionResponseInput = Optional<
  */
 export type ProofOfEventChallengeResponseInput = Optional<
   ProofOfEventChallengeResponse,
+  IgnoredResponseInputProperties
+>
+/**
+ * @category Wallet
+ */
+export type SimulatedProofOfEventChallengeResponseInput = Optional<
+  SimulatedProofOfEventChallengeResponse,
   IgnoredResponseInputProperties
 >
 /**

--- a/packages/beacon-types/src/types/beacon/messages/BeaconResponseInputMessage.ts
+++ b/packages/beacon-types/src/types/beacon/messages/BeaconResponseInputMessage.ts
@@ -80,3 +80,4 @@ export type BeaconResponseInputMessage =
   | AcknowledgeResponseInput
   | ErrorResponseInput
   | ProofOfEventChallengeResponseInput
+  | SimulatedProofOfEventChallengeResponseInput

--- a/packages/beacon-types/src/types/beacon/messages/BeaconResponseOutputMessage.ts
+++ b/packages/beacon-types/src/types/beacon/messages/BeaconResponseOutputMessage.ts
@@ -5,7 +5,8 @@ import {
   // EncryptPayloadResponse,
   BroadcastResponse,
   AccountInfo,
-  ProofOfEventChallengeResponse
+  ProofOfEventChallengeResponse,
+  SimulatedProofOfEventChallengeResponse
 } from '@airgap/beacon-types'
 
 /**
@@ -26,6 +27,11 @@ export type PermissionResponseOutput = PermissionResponse & {
  * @category DApp
  */
 export type ProofOfEventChallengeResponseOutput = ProofOfEventChallengeResponse
+
+/**
+ * @category DApp
+ */
+export type SimulatedProofOfEventChallengeResponseOutput = SimulatedProofOfEventChallengeResponse
 
 /**
  * @category DApp
@@ -55,3 +61,4 @@ export type BeaconResponseOutputMessage =
   // | EncryptPayloadResponseOutput
   | BroadcastResponseOutput
   | ProofOfEventChallengeResponseOutput
+  | SimulatedProofOfEventChallengeResponseOutput

--- a/packages/beacon-types/src/types/beacon/messages/SimulatedProofOfEventChallengeRequest.ts
+++ b/packages/beacon-types/src/types/beacon/messages/SimulatedProofOfEventChallengeRequest.ts
@@ -1,0 +1,7 @@
+import { BeaconBaseMessage, BeaconMessageType } from '@airgap/beacon-types'
+
+export interface SimulatedProofOfEventChallengeRequest extends BeaconBaseMessage {
+  type: BeaconMessageType.SimulatedProofOfEventChallengeRequest
+  payload: string // The payload that will be emitted.
+  contractAddress: string // The contract address of the abstracted account
+}

--- a/packages/beacon-types/src/types/beacon/messages/SimulatedProofOfEventChallengeResponse.ts
+++ b/packages/beacon-types/src/types/beacon/messages/SimulatedProofOfEventChallengeResponse.ts
@@ -1,0 +1,7 @@
+import { BeaconBaseMessage, BeaconMessageType } from '@airgap/beacon-types'
+
+export interface SimulatedProofOfEventChallengeResponse extends BeaconBaseMessage {
+  type: BeaconMessageType.SimulatedProofOfEventChallengeResponse
+  operationsList: string // Base64 encoded json
+  errorMessage: string
+}

--- a/packages/beacon-wallet/src/interceptors/IncomingRequestInterceptor.ts
+++ b/packages/beacon-wallet/src/interceptors/IncomingRequestInterceptor.ts
@@ -16,6 +16,7 @@ import {
   // EncryptPayloadRequestOutput
 } from '@airgap/beacon-types'
 import { AppMetadataManager, Logger } from '@airgap/beacon-core'
+import { SimulatedProofOfEventChallengeRequestOutput } from '@airgap/beacon-types/dist/esm/types/beacon/messages/BeaconRequestOutputMessage'
 
 const logger = new Logger('IncomingRequestInterceptor')
 
@@ -149,6 +150,19 @@ export class IncomingRequestInterceptor {
             message.senderId
           )
           const request: ProofOfEventChallengeRequestOutput = {
+            appMetadata,
+            ...message
+          }
+          interceptorCallback(request, connectionInfo)
+        }
+        break
+      case BeaconMessageType.SimulatedProofOfEventChallengeRequest:
+        {
+          const appMetadata: AppMetadata = await IncomingRequestInterceptor.getAppMetadata(
+            appMetadataManager,
+            message.senderId
+          )
+          const request: SimulatedProofOfEventChallengeRequestOutput = {
             appMetadata,
             ...message
           }

--- a/packages/beacon-wallet/src/interceptors/IncomingRequestInterceptor.ts
+++ b/packages/beacon-wallet/src/interceptors/IncomingRequestInterceptor.ts
@@ -169,6 +169,19 @@ export class IncomingRequestInterceptor {
           interceptorCallback(request, connectionInfo)
         }
         break
+      case BeaconMessageType.SimulatedProofOfEventChallengeRequest:
+        {
+          const appMetadata: AppMetadata = await IncomingRequestInterceptor.getAppMetadata(
+            appMetadataManager,
+            message.senderId
+          )
+          const request: SimulatedProofOfEventChallengeRequestOutput = {
+            appMetadata,
+            ...message
+          }
+          interceptorCallback(request, connectionInfo)
+        }
+        break
       default:
         logger.log('intercept', 'Message not handled')
         assertNever(message)

--- a/packages/beacon-wallet/src/interceptors/OutgoingResponseInterceptor.ts
+++ b/packages/beacon-wallet/src/interceptors/OutgoingResponseInterceptor.ts
@@ -22,7 +22,8 @@ import {
   BlockchainResponseV3,
   PermissionResponseV3,
   BeaconBaseMessage,
-  ProofOfEventChallengeResponse
+  ProofOfEventChallengeResponse,
+  SimulatedProofOfEventChallengeResponse
   // EncryptPayloadResponse
 } from '@airgap/beacon-types'
 import { getAddressFromPublicKey, CONTRACT_PREFIX, isValidAddress } from '@airgap/beacon-utils'
@@ -272,6 +273,16 @@ export class OutgoingResponseInterceptor {
       case BeaconMessageType.ProofOfEventChallengeResponse:
         {
           const response: ProofOfEventChallengeResponse = {
+            senderId,
+            version: '2',
+            ...message
+          }
+          interceptorCallback(response)
+        }
+        break
+      case BeaconMessageType.SimulatedProofOfEventChallengeResponse:
+        {
+          const response: SimulatedProofOfEventChallengeResponse = {
             senderId,
             version: '2',
             ...message


### PR DESCRIPTION
This PR adds the support for the [Tzip 28](https://gitlab.com/tezos/tzip/-/blob/a17642ac67c26744a864e67645705b0de3d98ff3/drafts/current/draft-simulated-proof-of-event/tzip-28.md): Simulated Proof of Event.

This PR fix the build fails with the PR https://github.com/airgap-it/beacon-sdk/pull/692 (related to this https://github.com/airgap-it/beacon-sdk/pull/731#issuecomment-1988764311)

@IsaccoSordo @AndreasGassmann please ping me if there is another issue with this PR, thanks.