### PR TITLE
Fix/ACTIVE_ACCOUNT_SET bugs

### DIFF
--- a/examples/dapp.html
+++ b/examples/dapp.html
@@ -275,7 +275,8 @@
         })
       }
 
-      client.subscribeToEvent('ACTIVE_ACCOUNT_SET', () => {
+      client.subscribeToEvent('ACTIVE_ACCOUNT_SET', (activeAccount) => {
+        console.log('ACTIVE_ACCOUNT_SET', activeAccount)
         updateActiveAccount()
       })
 

--- a/packages/beacon-core/src/transports/Transport.ts
+++ b/packages/beacon-core/src/transports/Transport.ts
@@ -63,7 +63,7 @@ export abstract class Transport<
   /**
    * The listeners that will be notified when new messages are coming in
    */
-  private listeners: ((message: unknown, connectionInfo: ConnectionContext) => void)[] = []
+  protected listeners: ((message: unknown, connectionInfo: ConnectionContext) => void)[] = []
 
   /**
    * Return the status of the connection

--- a/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
+++ b/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
@@ -120,7 +120,7 @@ export class WalletConnectTransport<
 
   public async disconnect(): Promise<void> {
     await this.client.close()
-
+    this.listeners = []
     return super.disconnect()
   }
 

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -171,7 +171,6 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     if (lastIndex > -1) {
       this.session = client.session.get(client.session.keys[lastIndex])
 
-      this.subscribeToSessionEvents(client)
       this.updateStorageWallet(this.session)
       this.setDefaultAccountAndNetwork()
     } else {


### PR DESCRIPTION
Fixes #757 & #758

The proper way to fix #757 would be to create a destroy() function that would make the Transport object eligible for garbage collection. That would reduce the risk for many bugs and prevent memory leakage. But since there is a concern for introducing regression bugs, I decided to keep the code changes to a minimum.