### PR TITLE
Fix: subscription management

### DIFF
--- a/examples/dapp.html
+++ b/examples/dapp.html
@@ -275,7 +275,8 @@
         })
       }
 
-      client.subscribeToEvent('ACTIVE_ACCOUNT_SET', () => {
+      client.subscribeToEvent('ACTIVE_ACCOUNT_SET', (account) => {
+        console.log('ACTIVE_ACCOUNT_SET received', account)
         updateActiveAccount()
       })
 
@@ -407,7 +408,6 @@
           .disconnect()
           .then(() => console.log('disconnected.'))
           .catch((err) => console.error(err.message))
-
       }
 
       const requestSimulatedProofOfEventChallenge = () => {

--- a/packages/beacon-core/src/clients/client/Client.ts
+++ b/packages/beacon-core/src/clients/client/Client.ts
@@ -225,7 +225,7 @@ export abstract class Client extends BeaconClient {
     // in beacon we subscribe to the transport on client init only
     // unsubscribing from the transport is only beneficial when running
     // a single page dApp.
-    // However while running a multiple tabs setup one of the dApps disconnects
+    // However, while running a multiple tabs setup, if one of the dApps disconnects
     // the others wont't recover until after a page refresh
 
     if (this.transportListeners.has(transport.type)) {

--- a/packages/beacon-core/src/clients/client/Client.ts
+++ b/packages/beacon-core/src/clients/client/Client.ts
@@ -93,9 +93,15 @@ export abstract class Client extends BeaconClient {
   }
 
   protected async cleanup() {
+    if (!this.subscriptions.length) {
+      return
+    }
+
     if (this._transport.isResolved()) {
       const transport = await this.transport
-      this.subscriptions.forEach((listener) => transport.removeListener(listener))
+      await Promise.all(
+        this.subscriptions.splice(0).map((listener) => transport.removeListener(listener))
+      )
     }
   }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -872,6 +872,7 @@ export class DAppClient extends Client {
       const peer = await this.getPeer(account)
       await this.setActivePeer(peer)
     } else {
+      await this.cleanup()
       await this.setActivePeer(undefined)
       await this.setTransport(undefined)
     }
@@ -2356,7 +2357,6 @@ export class DAppClient extends Client {
     await this.createStateSnapshot()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'start'))
     await this.clearActiveAccount()
-    await this.cleanup()
     await transport.disconnect()
     this.postMessageTransport = undefined
     this.p2pTransport = undefined

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -426,8 +426,15 @@ export class DAppClient extends Client {
         }
       }
 
-      if (!this.openRequests.has('session_update')) {
-        this.openRequests.set('session_update', new ExposedPromise())
+      if (this._transport.isResolved()) {
+        const transport = await this.transport
+
+        if (
+          transport instanceof WalletConnectTransport &&
+          !this.openRequests.has('session_update')
+        ) {
+          this.openRequests.set('session_update', new ExposedPromise())
+        }
       }
     }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -624,6 +624,12 @@ export class DAppClient extends Client {
     await this.destroy()
   }
 
+  /**
+   * Destroy the instance.
+   * WARNING: Call `destroy` whenever you no longer need dAppClient,
+   * as it frees internal subscriptions to the transport and therefore the instance may no longer work properly.
+   * If you wish to disconnect your dApp, use `disconnect` instead.
+   */
   async destroy(): Promise<void> {
     await this.createStateSnapshot()
     await super.destroy()

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -2348,12 +2348,12 @@ export class DAppClient extends Client {
 
     await this.createStateSnapshot()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'start'))
+    await this.clearActiveAccount()
     await this.cleanup()
+    await transport.disconnect()
     this.postMessageTransport = undefined
     this.p2pTransport = undefined
     this.walletConnectTransport = undefined
-    await this.clearActiveAccount()
-    await transport.disconnect()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'success'))
   }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -862,27 +862,19 @@ export class DAppClient extends Client {
 
       // Select the transport that matches the active account
       if (origin === Origin.EXTENSION) {
-        if (
-          this.postMessageTransport &&
-          this.postMessageTransport.connectionStatus !== TransportStatus.CONNECTED
-        ) {
-          await this.postMessageTransport.connect()
-        }
         await this.setTransport(this.postMessageTransport)
       } else if (origin === Origin.P2P) {
-        if (this.p2pTransport && this.p2pTransport.connectionStatus !== TransportStatus.CONNECTED) {
-          await this.p2pTransport.connect()
-        }
         await this.setTransport(this.p2pTransport)
       } else if (origin === Origin.WALLETCONNECT) {
-        if (
-          this.walletConnectTransport &&
-          this.walletConnectTransport.connectionStatus !== TransportStatus.CONNECTED
-        ) {
-          await this.walletConnectTransport.connect()
-        }
         await this.setTransport(this.walletConnectTransport)
         this.walletConnectTransport?.forceUpdate('INIT')
+      }
+      if (this._transport.isResolved()) {
+        const transport = await this.transport
+
+        if (transport.connectionStatus === TransportStatus.NOT_CONNECTED) {
+          await transport.connect()
+        }
       }
       const peer = await this.getPeer(account)
       await this.setActivePeer(peer)

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -425,6 +425,10 @@ export class DAppClient extends Client {
           }
         }
       }
+
+      if (!this.openRequests.has('session_update')) {
+        this.openRequests.set('session_update', new ExposedPromise())
+      }
     }
 
     this.storageValidator
@@ -2349,6 +2353,7 @@ export class DAppClient extends Client {
     this.p2pTransport = undefined
     this.walletConnectTransport = undefined
     await this.clearActiveAccount()
+    await transport.disconnect()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'success'))
   }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -2344,11 +2344,11 @@ export class DAppClient extends Client {
 
     await this.createStateSnapshot()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'start'))
+    await this.cleanup()
     this.postMessageTransport = undefined
     this.p2pTransport = undefined
     this.walletConnectTransport = undefined
     await this.clearActiveAccount()
-    await transport.disconnect()
     this.sendMetrics('performance-metrics/save', await this.buildPayload('disconnect', 'success'))
   }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -355,7 +355,6 @@ export class DAppClient extends Client {
               await this.events.emit(BeaconEvent.CHANNEL_CLOSED)
             }
           } else if (typedMessage.message?.type === BeaconMessageType.ChangeAccountRequest) {
-            console.log('onNewAccount called.', 1)
             await this.onNewAccount(typedMessage.message as ChangeAccountRequest, connectionInfo)
           } else {
             logger.error('handleResponse', 'no request found for id ', message.id, message)

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -862,17 +862,31 @@ export class DAppClient extends Client {
 
       // Select the transport that matches the active account
       if (origin === Origin.EXTENSION) {
+        if (
+          this.postMessageTransport &&
+          this.postMessageTransport.connectionStatus !== TransportStatus.CONNECTED
+        ) {
+          await this.postMessageTransport.connect()
+        }
         await this.setTransport(this.postMessageTransport)
       } else if (origin === Origin.P2P) {
+        if (this.p2pTransport && this.p2pTransport.connectionStatus !== TransportStatus.CONNECTED) {
+          await this.p2pTransport.connect()
+        }
         await this.setTransport(this.p2pTransport)
       } else if (origin === Origin.WALLETCONNECT) {
+        if (
+          this.walletConnectTransport &&
+          this.walletConnectTransport.connectionStatus !== TransportStatus.CONNECTED
+        ) {
+          await this.walletConnectTransport.connect()
+        }
         await this.setTransport(this.walletConnectTransport)
         this.walletConnectTransport?.forceUpdate('INIT')
       }
       const peer = await this.getPeer(account)
       await this.setActivePeer(peer)
     } else {
-      await this.cleanup()
       await this.setActivePeer(undefined)
       await this.setTransport(undefined)
     }

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -626,6 +626,7 @@ export class DAppClient extends Client {
 
   /**
    * Destroy the instance.
+   * 
    * WARNING: Call `destroy` whenever you no longer need dAppClient,
    * as it frees internal subscriptions to the transport and therefore the instance may no longer work properly.
    * If you wish to disconnect your dApp, use `disconnect` instead.

--- a/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
+++ b/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
@@ -9,7 +9,8 @@ import {
   StorageKey,
   WalletConnectPairingRequest,
   NetworkType,
-  AccountInfo
+  AccountInfo,
+  TransportType
 } from '@airgap/beacon-types'
 import { Transport, PeerManager } from '@airgap/beacon-core'
 import { SignClientTypes } from '@walletconnect/types'
@@ -24,7 +25,7 @@ export class WalletConnectTransport<
   T extends WalletConnectPairingRequest | ExtendedWalletConnectPairingResponse,
   K extends StorageKey.TRANSPORT_WALLETCONNECT_PEERS_DAPP
 > extends Transport<T, K, WalletConnectCommunicationClient> {
-  // public readonly type: TransportType = TransportType.WALLETCONNECT
+  public readonly type: TransportType = TransportType.WALLETCONNECT
 
   constructor(
     name: string,

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -169,8 +169,7 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
 
     if (lastIndex > -1) {
       this.session = client.session.get(client.session.keys[lastIndex])
-
-      this.subscribeToSessionEvents(client)
+      
       this.updateStorageWallet(this.session)
       this.setDefaultAccountAndNetwork()
     } else {

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -718,6 +718,8 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
   public async close() {
     this.storage.backup()
     await this.closePairings()
+    this.activeListeners.clear()
+    this.channelOpeningListeners.clear()
   }
 
   private subscribeToSessionEvents(signClient: Client): void {

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -743,14 +743,7 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
 
       this.session = session
 
-      this.updateActiveAccount(event.params.namespaces)
-      this.notifyListenersWithPermissionResponse(
-        this.session,
-        {
-          type: this.wcOptions.network
-        },
-        'session_update'
-      )
+      this.updateActiveAccount(event.params.namespaces, session)
     })
 
     signClient.on('session_delete', (event) => {
@@ -782,7 +775,10 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     this.notifyListeners(this.getTopicFromSession(session), acknowledgeResponse)
   }
 
-  private async updateActiveAccount(namespaces: SessionTypes.Namespaces) {
+  private async updateActiveAccount(
+    namespaces: SessionTypes.Namespaces,
+    session: SessionTypes.Struct
+  ) {
     try {
       const accounts = this.getTezosNamespace(namespaces).accounts
       if (accounts.length) {
@@ -814,6 +810,14 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
           scopes: [PermissionScope.SIGN, PermissionScope.OPERATION_REQUEST],
           walletType: 'implicit'
         })
+      } else {
+        this.notifyListenersWithPermissionResponse(
+          session,
+          {
+            type: this.wcOptions.network
+          },
+          'session_update'
+        )
       }
     } catch {}
   }

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -323,7 +323,8 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
 
   private async notifyListenersWithPermissionResponse(
     session: SessionTypes.Struct,
-    network: Network
+    network: Network,
+    sessionEventId?: string
   ) {
     let publicKey: string | undefined
     if (
@@ -378,7 +379,7 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       publicKey,
       network,
       scopes: [PermissionScope.SIGN, PermissionScope.OPERATION_REQUEST],
-      id: this.messageIds.pop() ?? '',
+      id: sessionEventId ?? this.messageIds.pop() ?? '',
       walletType: 'implicit'
     }
 
@@ -741,9 +742,13 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       this.session = session
 
       this.updateActiveAccount(event.params.namespaces)
-      this.notifyListenersWithPermissionResponse(this.session, {
-        type: this.wcOptions.network
-      })
+      this.notifyListenersWithPermissionResponse(
+        this.session,
+        {
+          type: this.wcOptions.network
+        },
+        'session_update'
+      )
     })
 
     signClient.on('session_delete', (event) => {

--- a/packages/beacon-utils/src/utils/crypto.ts
+++ b/packages/beacon-utils/src/utils/crypto.ts
@@ -204,7 +204,7 @@ export async function getAddressFromPublicKey(publicKey: string): Promise<string
  *
  * @param publicKey
  */
-export async function prefixPublicKey(publicKey: string): Promise<string> {
+export function prefixPublicKey(publicKey: string): string {
   if (publicKey.length !== 64) {
     return publicKey
   }

--- a/packages/beacon-wallet/src/client/WalletClient.ts
+++ b/packages/beacon-wallet/src/client/WalletClient.ts
@@ -465,7 +465,6 @@ export class WalletClient extends Client {
       await this.removePeer(peer as any)
     }
 
-    await this.cleanup()
     await transport.disconnect()
 
     return

--- a/packages/beacon-wallet/src/client/WalletClient.ts
+++ b/packages/beacon-wallet/src/client/WalletClient.ts
@@ -465,6 +465,9 @@ export class WalletClient extends Client {
       await this.removePeer(peer as any)
     }
 
+    await this.cleanup()
+    await transport.disconnect()
+
     return
   }
 }


### PR DESCRIPTION
This PR addresses multiple instances of failed subscriptions cleanup in Beacon; also there is no need to undergo a big refactor.
Namely I found 3 issues:
1. The `Client` instance once it had subscribed to the transport, it never cleared its subscriptions. Now we keep track of each subscription and remove each one of them on Client destroy (this needs to be managed on the client instance not on the transport one)
2. WalletConnectCommunication client never cleared its subscriptions maps when closing the client
3. Because we are subscribing to WC session events, DAppClient wouldn’t behave correctly while receiving an event (`session_update` for instance) because our logic assumed that we would have always end up in a one direction flow (one request from the dApp, one response from the Wallet). However, this is no longer true and there is the need to separately acknowledge messages coming from session events.