### PR TITLE
fix: multitab send

### DIFF
--- a/packages/beacon-dapp/src/utils/tzkt-blockexplorer.ts
+++ b/packages/beacon-dapp/src/utils/tzkt-blockexplorer.ts
@@ -21,7 +21,7 @@ export class TzktBlockExplorer extends BlockExplorer {
       [NetworkType.NAIROBINET]: 'https://nairobinet.tzkt.io',
       [NetworkType.OXFORDNET]: 'https://oxfordnet.tzkt.io',
       [NetworkType.PARISNET]: 'https://parisnet.tzkt.io',
-      [NetworkType.CUSTOM]: 'https://oxfordnet.tzkt.io'
+      [NetworkType.CUSTOM]: 'https://parisnet.tzkt.io'
     }
   ) {
     super(rpcUrls)

--- a/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
+++ b/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
@@ -541,7 +541,7 @@ export class P2PCommunicationClient extends CommunicationClient {
     const roomId = await this.getRelevantRoom(recipient)
 
     // Before we send the message, we have to wait for the join to be accepted.
-    await this.waitForJoin(roomId) // TODO: This can probably be removed because we are now waiting inside the get room method
+    // await this.waitForJoin(roomId) // TODO: This can probably be removed because we are now waiting inside the get room method
 
     const encryptedMessage = await encryptCryptoboxPayload(message, sharedKey.send)
 


### PR DESCRIPTION
With two or more tabs open, disconnecting and reconnecting on one would have cause all the other tabs to enter an almost endless loop while trying to join the room.