### PR TITLE
Add support for newly launched parisnet in tezos protocol.

### DIFF
--- a/packages/beacon-dapp/src/utils/tzkt-blockexplorer.ts
+++ b/packages/beacon-dapp/src/utils/tzkt-blockexplorer.ts
@@ -20,7 +20,8 @@ export class TzktBlockExplorer extends BlockExplorer {
       [NetworkType.MUMBAINET]: 'https://mumbainet.tzkt.io',
       [NetworkType.NAIROBINET]: 'https://nairobinet.tzkt.io',
       [NetworkType.OXFORDNET]: 'https://oxfordnet.tzkt.io',
-      [NetworkType.CUSTOM]: 'https://oxfordnet.tzkt.io'
+      [NetworkType.PARISNET]: 'https://parisnet.tzkt.io',
+      [NetworkType.CUSTOM]: 'https://parisnet.tzkt.io'
     }
   ) {
     super(rpcUrls)

--- a/packages/beacon-types/src/types/beacon/NetworkType.ts
+++ b/packages/beacon-types/src/types/beacon/NetworkType.ts
@@ -15,5 +15,6 @@ export enum NetworkType {
   MUMBAINET = 'mumbainet',
   NAIROBINET = 'nairobinet',
   OXFORDNET = 'oxfordnet',
+  PARISNET = 'parisnet', 
   CUSTOM = 'custom'
 }

--- a/packages/beacon-types/src/types/ui.ts
+++ b/packages/beacon-types/src/types/ui.ts
@@ -32,6 +32,7 @@ export interface WebApp extends AppBase {
     [NetworkType.MUMBAINET]?: string
     [NetworkType.NAIROBINET]?: string
     [NetworkType.OXFORDNET]?: string
+    [NetworkType.PARISNET]?: string
     [NetworkType.CUSTOM]?: string
   }
 }

--- a/scripts/blockchains/tezos-sapling.ts
+++ b/scripts/blockchains/tezos-sapling.ts
@@ -18,6 +18,7 @@ export enum NetworkType {
   MUMBAINET = 'mumbainet',
   NAIROBINET = 'nairobinet',
   OXFORDNET = 'oxfordnet',
+  PARISNET = 'parisnet',
   CUSTOM = 'custom'
 }
 

--- a/scripts/blockchains/tezos.ts
+++ b/scripts/blockchains/tezos.ts
@@ -18,6 +18,7 @@ export enum NetworkType {
   MUMBAINET = 'mumbainet',
   NAIROBINET = 'nairobinet',
   OXFORDNET = 'oxfordnet',
+  PARISNET = 'parisnet',
   CUSTOM = 'custom'
 }
 
@@ -74,7 +75,8 @@ export const tezosWebList: WebApp[] = [
       [NetworkType.LIMANET]: 'https://metamask.tezos.com/',
       [NetworkType.MUMBAINET]: 'https://metamask.tezos.com/',
       [NetworkType.NAIROBINET]: 'https://metamask.tezos.com/',
-      [NetworkType.OXFORDNET]: 'https://metamask.tezos.com/'
+      [NetworkType.OXFORDNET]: 'https://metamask.tezos.com/',
+      [NetworkType.PARISNET]: 'https://metamask.tezos.com/'
     }
   },
   {
@@ -100,7 +102,9 @@ export const tezosWebList: WebApp[] = [
       [NetworkType.LIMANET]: 'https://limanet.kukai.app',
       [NetworkType.MUMBAINET]: 'https://mumbainet.kukai.app',
       [NetworkType.NAIROBINET]: 'https://nairobinet.kukai.app',
-      [NetworkType.OXFORDNET]: 'https://oxfordnet.kukai.app'
+      [NetworkType.OXFORDNET]: 'https://oxfordnet.kukai.app',
+      [NetworkType.PARISNET]: 'https://parisnet.kukai.app',
+      
     }
   },
 
@@ -126,7 +130,8 @@ export const tezosWebList: WebApp[] = [
       [NetworkType.LIMANET]: 'https://ghostnet.tzsafe.marigold.dev',
       [NetworkType.MUMBAINET]: 'https://ghostnet.tzsafe.marigold.dev',
       [NetworkType.NAIROBINET]: 'https://ghostnet.tzsafe.marigold.dev',
-      [NetworkType.OXFORDNET]: 'https://ghostnet.tzsafe.marigold.dev'
+      [NetworkType.OXFORDNET]: 'https://ghostnet.tzsafe.marigold.dev',
+      [NetworkType.PARISNET]: 'https://ghostnet.tzsafe.marigold.dev'
     }
   }
 ]


### PR DESCRIPTION
Paris protocol was launched recently for tezos blockchain. Tzkt already has launched [website](https://parisnet.tzkt.io) to support it. Need to include it in beacon sdk to access through the SDK using NetworkTypes