### PR TITLE
Extensions on mobile platforms

### DIFF
--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -606,6 +606,10 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
           }
         }
         setIsLoading(false)
+      } else if (_isMobileOS && hasExtension()) {
+        handleClickConnectExtension()
+
+        setIsLoading(false)
       } else if (wallet?.types.includes('ios') && _isMobileOS) {
         setCodeQR('')
 

--- a/packages/beacon-ui/src/ui/alert/index.tsx
+++ b/packages/beacon-ui/src/ui/alert/index.tsx
@@ -820,7 +820,7 @@ const openAlert = async (config: AlertConfig): Promise<string> => {
                           ]}
                         />
                       )}
-                      {!isMobile() && currentWallet()?.types.includes('extension') && (
+                      {currentWallet()?.types.includes('extension') && (
                         <Info
                           border
                           title={


### PR DESCRIPTION
At the moment Beacon UI does not expect to have extensions installed, when `navigator.userAgent` is of mobile nature. It does check their presence (pings are received by extension), but will not provide corresponding user-actions (render corresponding buttons).

Thus, there is no attempt to connect with extension at all. Noticed this, while adapting our wallet extension for mobile-first browsers.

With this consideration, UI is up to be decided, but desired effect is reflected by this PR.