### PR TITLE
fix: disconnect stuck state

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -891,6 +891,7 @@ export class DAppClient extends Client {
         this.postMessageTransport = this.p2pTransport = this.walletConnectTransport = undefined
         if (this.multiTabChannel.isLeader()) {
           await transport.disconnect()
+          this.openRequestsOtherTabs.clear()
         } else {
           this.multiTabChannel.postMessage({
             type: 'DISCONNECT'

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -387,10 +387,6 @@ export class DAppClient extends Client {
           await handleDisconnect()
         } else if (typedMessage.type === BeaconMessageType.ChangeAccountRequest) {
           await this.onNewAccount(typedMessage as ChangeAccountRequest, connectionInfo)
-        } else {
-          // This needs to be a debug log because, due to the BC feature,
-          // IDs generated in another tab will also be handled here.
-          logger.debug('handleResponse', 'no request found for id ', message.id, message)
         }
       }
 

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -904,7 +904,7 @@ export class DAppClient extends Client {
               errorType: BeaconErrorType.ABORTED_ERROR,
               id,
               senderId: '',
-              version: '1'
+              version: '2'
             })
           })
         this.openRequests.clear()

--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -895,14 +895,19 @@ export class DAppClient extends Client {
           this.multiTabChannel.postMessage({
             type: 'DISCONNECT'
           })
-          Array.from(this.openRequests.values()).forEach((promise) =>
+        }
+        Array.from(this.openRequests.entries())
+          .filter(([id, _promise]) => id !== 'session_update')
+          .forEach(([id, promise]) => {
             promise.reject({
               type: BeaconMessageType.Error,
-              errorType: BeaconErrorType.ABORTED_ERROR
-            } as any)
-          )
-          this.openRequests.clear()
-        }
+              errorType: BeaconErrorType.ABORTED_ERROR,
+              id,
+              senderId: '',
+              version: '1'
+            })
+          })
+        this.openRequests.clear()
         this.debounceSetActiveAccount = false
       }
     }

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -172,20 +172,6 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
     this.signClient?.core.pairing.events.removeAllListeners('pairing_expire')
   }
 
-  private abortErrorBuilder() {
-    if (!this.messageIds.length) {
-      return
-    }
-
-    const errorResponse: any = {
-      type: BeaconMessageType.Disconnect,
-      id: this.messageIds.pop(),
-      errorType: BeaconErrorType.ABORTED_ERROR
-    }
-    this.session && this.notifyListeners(this.getTopicFromSession(this.session), errorResponse)
-    this.messageIds = [] // reset
-  }
-
   async unsubscribeFromEncryptedMessages(): Promise<void> {
     this.activeListeners.clear()
     this.channelOpeningListeners.clear()
@@ -700,9 +686,9 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
 
   public async close() {
     this.storage.backup()
-    this.abortErrorBuilder()
     await this.closePairings()
     this.unsubscribeFromEncryptedMessages()
+    this.messageIds = []
   }
 
   private subscribeToSessionEvents(signClient: Client): void {


### PR DESCRIPTION
Resolved a stuck state that occurred after disconnecting a dApp while waiting for a response from the wallet, and then tried to sync.