### PR TITLE
Exploring cleanup of BeaconDapp when destroy is called

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -662,6 +662,10 @@ export class DAppClient extends Client {
   async destroy(): Promise<void> {
     await this.createStateSnapshot()
     await super.destroy()
+    await this.postMessageTransport?.disconnect()
+    await this.p2pTransport?.disconnect()
+    await this.walletConnectTransport?.disconnect()
+    this.multiTabChannel.destroy()
   }
 
   public async init(transport?: Transport<any>): Promise<TransportType> {


### PR DESCRIPTION
This is a POC PR, not a well planned contribution.
This is related to #799 

We also needed to make the following change to the file: `node_modules/broadcast-channel/dist/es5node/broadcast-channel.js`, lines 194-196:

```diff
  var awaitPrepare = broadcastChannel._prepP ? broadcastChannel._prepP : _util.PROMISE_RESOLVED_VOID;
  return awaitPrepare.then(function () {
+    if (broadcastChannel.closed) {
+      return;
+    }
    var sendPromise = broadcastChannel.method.postMessage(broadcastChannel._state, msgObj);

    // add/remove to unsent messages list
```

Our knowledge of Beacon-SDK source code is limited, and you might be able to do the same thing in a much cleaner way.
Also, our changes might have side effects we are not aware of.