### PR TITLE
fix: ScriptedContracts in Origination

### DIFF
--- a/packages/beacon-types/src/types/tezos/operations/Origination.ts
+++ b/packages/beacon-types/src/types/tezos/operations/Origination.ts
@@ -1,4 +1,5 @@
 import { TezosBaseOperation, TezosOperationType } from '../../..'
+import { ScriptedContracts } from '../common'
 
 /**
  * @internalapi
@@ -13,5 +14,5 @@ export interface TezosOriginationOperation extends TezosBaseOperation {
   storage_limit: string
   balance: string
   delegate?: string
-  script: string
+  script: ScriptedContracts
 }


### PR DESCRIPTION
What:
Changed the type of `TezosOriginationOperation.script` from `string` to `ScriptedContracts`.

Why:
The `string` type doesn't match the [Tezos RPC specification](https://tezos.gitlab.io/shell/p2p_api.html#origination-tag-109).

Details:

The Origination operation has a `script` field with the following parameters: ([doc](https://tezos.gitlab.io/shell/p2p_api.html#origination-tag-109))
 - `size`: determined from data
 - `contents`: `$alpha.scripted.contracts` 
 
The `ScriptedContracts` type is matching the definition of $alpha.scripted.contracts ([doc](https://tezos.gitlab.io/shell/p2p_api.html#alpha-scripted-contracts))
 - `# bytes in next field`, 4 bytes, unsigned 30-bit big-endian integer
 - `code`, Variable, bytes
 - `# bytes in next field`, 4 bytes, unsigned 30-bit big-endian integer
 - `storage`, Variable, bytes

 Fixed the definition of `TezosOriginationOperation` to match the Tezos RPC specification.