### PR TITLE
fix: export for TezosPreEndorsementOperation

### DIFF
--- a/packages/beacon-types/src/index.ts
+++ b/packages/beacon-types/src/index.ts
@@ -163,6 +163,7 @@ import { TezosEndorsementWithSlotOperation } from './types/tezos/operations/Endo
 import { TezosFailingNoopOperation } from './types/tezos/operations/FailingNoop'
 import { TezosIncreasePaidStorageOperation } from './types/tezos/operations/IncreasePaidStorage'
 import { TezosPreAttestationOperation } from './types/tezos/operations/PreAttestation'
+import { TezosPreEndorsementOperation } from './types/tezos/operations/PreEndorsement'
 import { TezosRegisterGlobalConstantOperation } from './types/tezos/operations/RegisterGlobalConstant'
 import { TezosSetDepositsLimitOperation } from './types/tezos/operations/SetDepositsLimit'
 import { TezosSmartRollupAddMessagesOperation } from './types/tezos/operations/SmartRollupAddMessages'
@@ -232,6 +233,7 @@ export {
   PartialTezosSetDepositsLimitOperation,
   TezosAttestationOperation,
   TezosPreAttestationOperation,
+  TezosPreEndorsementOperation,
   TezosSetDepositsLimitOperation,
   TezosDoublePreAttestationEvidenceOperation,
   TezosDoublePreEndorsementEvidenceOperation,


### PR DESCRIPTION
Adding `TezosPreEndorsementOperation` to the list of exported types.
This is the only type in `PartialTezosOperation` which is not exported.