### PR TITLE
fix: aligned TezosTransactionParameters with Tezos p2p API

### DIFF
--- a/packages/beacon-types/src/types/tezos/TezosTransactionParameters.ts
+++ b/packages/beacon-types/src/types/tezos/TezosTransactionParameters.ts
@@ -5,6 +5,6 @@ import { MichelineMichelsonV1Expression } from './MichelineMichelsonV1Expression
  * @category Tezos
  */
 export interface TezosTransactionParameters {
-  entrypoint: 'default' | 'root' | 'do' | 'set_delegate' | 'remove_delegate' | string
+  entrypoint: 'default' | 'root' | 'do' | 'set_delegate' | 'remove_delegate' | 'deposit' | 'stake' | 'unstake' | 'finalize_unstake' | 'set_delegate_parameters' | string
   value: MichelineMichelsonV1Expression
 }


### PR DESCRIPTION
Following the definition in tezos docs:
https://tezos.gitlab.io/shell/p2p_api.html#alpha-entrypoint-determined-from-data-8-bit-tag