### PR TITLE
fix: mobile broken state when multiple tabs are open

### DIFF
--- a/packages/beacon-dapp/src/dapp-client/DAppClient.ts
+++ b/packages/beacon-dapp/src/dapp-client/DAppClient.ts
@@ -940,6 +940,7 @@ export class DAppClient extends Client {
         await this.setTransport(this.p2pTransport)
       } else if (origin === Origin.WALLETCONNECT) {
         await this.setTransport(this.walletConnectTransport)
+        this.walletConnectTransport?.forceUpdate('INIT')
       }
       if (this._transport.isResolved()) {
         const transport = await this.transport
@@ -1080,7 +1081,7 @@ export class DAppClient extends Client {
     const isWCInstance = isResolved && (await this.transport) instanceof WalletConnectTransport
     const isLeader = this.multiTabChannel.isLeader()
 
-    return !isResolved || (isResolved && (!isWCInstance || (isWCInstance && isLeader)))
+    return !isResolved || isWCInstance || isLeader || isMobileOS(window)
   }
 
   /**

--- a/packages/beacon-dapp/src/events.ts
+++ b/packages/beacon-dapp/src/events.ts
@@ -40,7 +40,7 @@ import {
   // EncryptionOperation
 } from '@airgap/beacon-core'
 import { shortenString } from './utils/shorten-string'
-import { isMobile } from '@airgap/beacon-ui'
+import { isMobile, isMobileOS } from '@airgap/beacon-ui'
 
 const logger = new Logger('BeaconEvents')
 
@@ -261,6 +261,7 @@ const showSentToast = async (data: RequestSentInfo): Promise<void> => {
     body: `Request sent to\u00A0 {{wallet}}`,
     walletInfo: data.walletInfo,
     state: 'loading',
+    timer: isMobileOS(window) ? SUCCESS_TIMER : undefined,
     actions,
     openWalletAction
   }).catch((toastError) => console.error(toastError))

--- a/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
+++ b/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
@@ -39,7 +39,7 @@ export class WalletConnectTransport<
   ) {
     super(
       name,
-      WalletConnectCommunicationClient.getInstance(wcOptions, isLeader),
+      WalletConnectCommunicationClient.getInstance(wcOptions),
       new PeerManager<K>(storage, storageKey)
     )
   }
@@ -88,10 +88,6 @@ export class WalletConnectTransport<
     return !!this.client.disconnectionEvents.size
   }
 
-  closeClient() {
-    this.client.closeSignClient()
-  }
-
   public async hasPairings() {
     return (await this.client.storage.hasPairings())
       ? true
@@ -104,8 +100,17 @@ export class WalletConnectTransport<
       : !!this.client.signClient?.session.getAll()?.length
   }
 
+  /**
+   * Forcefully updates any DApps running on the same session
+   * Typical use case: localStorage changes to reflect to indexDB
+   * @param type the message type
+   */
+  public forceUpdate(type: string) {
+    this.client.storage.notify(type)
+  }
+
   public async getPeers(): Promise<T[]> {
-    const client = WalletConnectCommunicationClient.getInstance(this.wcOptions, this.isLeader)
+    const client = WalletConnectCommunicationClient.getInstance(this.wcOptions)
     const session = client.currentSession()
     if (!session) {
       return []

--- a/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
+++ b/packages/beacon-transport-walletconnect/src/WalletConnectTransport.ts
@@ -39,7 +39,7 @@ export class WalletConnectTransport<
   ) {
     super(
       name,
-      WalletConnectCommunicationClient.getInstance(wcOptions),
+      WalletConnectCommunicationClient.getInstance(wcOptions, isLeader),
       new PeerManager<K>(storage, storageKey)
     )
   }
@@ -110,7 +110,7 @@ export class WalletConnectTransport<
   }
 
   public async getPeers(): Promise<T[]> {
-    const client = WalletConnectCommunicationClient.getInstance(this.wcOptions)
+    const client = WalletConnectCommunicationClient.getInstance(this.wcOptions, this.isLeader)
     const session = client.currentSession()
     if (!session) {
       return []

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -4,7 +4,8 @@ import {
   Serializer,
   ClientEvents,
   Logger,
-  WCStorage
+  WCStorage,
+  SDK_VERSION
 } from '@airgap/beacon-core'
 import Client from '@walletconnect/sign-client'
 import { ProposalTypes, SessionTypes, SignClientTypes } from '@walletconnect/types'
@@ -48,6 +49,7 @@ import {
 import { generateGUID, getAddressFromPublicKey, isPublicKeySC } from '@airgap/beacon-utils'
 
 const TEZOS_PLACEHOLDER = 'tezos'
+const BEACON_SDK_VERSION = 'beacon_sdk_version'
 const logger = new Logger('WalletConnectCommunicationClient')
 
 export interface PermissionScopeParam {
@@ -621,10 +623,10 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       },
       optionalNamespaces: {
         [TEZOS_PLACEHOLDER]: this.permissionScopeParamsToNamespaces(optionalPermissionScopeParams)
+      },
+      sessionProperties: {
+        [BEACON_SDK_VERSION]: SDK_VERSION
       }
-      // sessionProperties: {
-      //   [BEACON_SDK_VERSION]: SDK_VERSION
-      // }
     }
 
     const { uri, approval } = await signClient.connect(connectParams).catch((error) => {
@@ -1044,7 +1046,10 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       optionalNamespaces: {
         [TEZOS_PLACEHOLDER]: this.permissionScopeParamsToNamespaces(optionalPermissionScopeParams)
       },
-      pairingTopic
+      sessionProperties: {
+        [BEACON_SDK_VERSION]: SDK_VERSION
+      }
+      // pairingTopic
     }
 
     logger.debug('Checking wallet readiness', [pairingTopic])

--- a/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
+++ b/packages/beacon-transport-walletconnect/src/communication-client/WalletConnectCommunicationClient.ts
@@ -1048,8 +1048,8 @@ export class WalletConnectCommunicationClient extends CommunicationClient {
       },
       sessionProperties: {
         [BEACON_SDK_VERSION]: SDK_VERSION
-      }
-      // pairingTopic
+      },
+      pairingTopic
     }
 
     logger.debug('Checking wallet readiness', [pairingTopic])


### PR DESCRIPTION
`BroadcastChannel` does not work on mobile. 
When the leader tab gets hidden, it enters a "suspended" state that prevents other tabs from communicating with it. 
This PR adds back the refresh logic from v4.2.2 and disables the ping only on mobile devices, since it is unreliable and may cause issues during runtime.