### PR TITLE
feat(transport): add ECAD relay servers to NORTH_AMERICA_WEST

### DIFF
--- a/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
+++ b/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
@@ -56,7 +56,13 @@ const REGIONS_AND_SERVERS: NodeDistributions = {
     'beacon-node-1.hope-5.papers.tech'
   ],
   [Regions.NORTH_AMERICA_EAST]: ['beacon-node-1.beacon-server-1.papers.tech'],
-  [Regions.NORTH_AMERICA_WEST]: ['beacon-node-1.beacon-server-2.papers.tech'],
+  [Regions.NORTH_AMERICA_WEST]: [
+    'beacon-node-1.beacon-server-2.papers.tech',
+    'beacon-1.ecadinfra.com',
+    'beacon-2.ecadinfra.com',
+    'beacon-3.ecadinfra.com',
+    'beacon-4.ecadinfra.com'
+  ],
   [Regions.ASIA_EAST]: ['beacon-node-1.beacon-server-3.papers.tech'],
   [Regions.AUSTRALIA]: ['beacon-node-1.beacon-server-4.papers.tech']
 }


### PR DESCRIPTION
## Summary

- Adds four ECAD Infrastructure relay servers (`beacon-{1-4}.ecadinfra.com`) to the `NORTH_AMERICA_WEST` region
- Improves relay coverage in western North America (currently only one node in the region)
- ECAD servers are running Synapse v1.147.1 with the standard `crypto_auth_provider` and `beacon_info_module`

## Changes

Single file change to `packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts`, adding four servers to the existing `REGIONS_AND_SERVERS` constant.

## Test plan

- [ ] Verify ECAD servers respond to `/_synapse/client/beacon/info` with valid region, known_servers, and timestamp
- [ ] Verify federation between ECAD and existing AirGap relay servers
- [ ] Test dApp-wallet pairing with SDK client selecting an ECAD server