### PR TITLE
fix: recover from dead relay node in getRelayServer

### DIFF
--- a/packages/beacon-transport-matrix/__tests__/communication-client/P2PCommunicationClient.test.ts
+++ b/packages/beacon-transport-matrix/__tests__/communication-client/P2PCommunicationClient.test.ts
@@ -15,6 +15,8 @@ jest.mock('@airgap/beacon-utils', () => {
         this._resolve = res
         this._reject = rej
       })
+      // Prevent unhandled rejection when promise is rejected without a concurrent awaiter
+      this.promise.catch(() => {})
     }
     resolve(value: T) {
       this._resolve(value)
@@ -150,12 +152,111 @@ describe('P2PCommunicationClient', () => {
         }
       })
       const info = await client.getBeaconInfo('relay.test')
-      expect(axios.get).toHaveBeenCalledWith('https://relay.test/_synapse/client/beacon/info')
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://relay.test/_synapse/client/beacon/info',
+        { timeout: 10_000 }
+      )
       expect(info).toEqual({
         region: 'eu',
         known_servers: ['a', 'b'],
         timestamp: 9876
       })
+    })
+  })
+
+  describe('getRelayServer (dead node recovery)', () => {
+    let freshClient: P2PCommunicationClient
+
+    beforeEach(() => {
+      freshClient = new P2PCommunicationClient('MyApp', fakeKeyPair as any, 2, mockStorage as any)
+    })
+
+    it('falls through to server discovery when stored node is unreachable', async () => {
+      // Stored node exists but is dead
+      mockStorage.get.mockResolvedValue('dead-node.papers.tech')
+      mockStorage.delete.mockResolvedValue(undefined)
+      mockStorage.set.mockResolvedValue(undefined)
+
+      // First call (stored node) rejects, second call (discovery probe) succeeds
+      ;(axios.get as jest.Mock)
+        .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+        .mockResolvedValue({
+          data: { region: 'eu', known_servers: ['a'], timestamp: 5000 }
+        })
+
+      const result = await freshClient.getRelayServer()
+
+      // Should have deleted the dead node from storage
+      expect(mockStorage.delete).toHaveBeenCalledWith(StorageKey.MATRIX_SELECTED_NODE)
+
+      // Should have resolved via discovery
+      expect(result.server).toBeDefined()
+      expect(result.timestamp).toBe(5000)
+    })
+
+    it('uses stored node when it is reachable', async () => {
+      mockStorage.get.mockResolvedValue('healthy-node.papers.tech')
+
+      ;(axios.get as jest.Mock).mockResolvedValue({
+        data: { region: 'eu', known_servers: ['a'], timestamp: 7777 }
+      })
+
+      const result = await freshClient.getRelayServer()
+
+      expect(result.server).toBe('healthy-node.papers.tech')
+      expect(result.timestamp).toBe(7777)
+      // Should NOT have deleted the node
+      expect(mockStorage.delete).not.toHaveBeenCalledWith(StorageKey.MATRIX_SELECTED_NODE)
+    })
+
+    it('rejects ExposedPromise when all servers fail, preventing concurrent caller deadlock', async () => {
+      mockStorage.get.mockResolvedValue('')
+      mockStorage.delete.mockResolvedValue(undefined)
+
+      // All discovery probes fail
+      ;(axios.get as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'))
+
+      await expect(freshClient.getRelayServer()).rejects.toThrow()
+
+      // The ExposedPromise should be cleared so subsequent callers get a fresh attempt
+      expect((freshClient as any).relayServer).toBeUndefined()
+    })
+
+    it('resets and retries when cached relay server becomes unreachable on timestamp refresh', async () => {
+      mockStorage.get.mockResolvedValue('')
+      mockStorage.set.mockResolvedValue(undefined)
+      mockStorage.delete.mockResolvedValue(undefined)
+
+      // First getRelayServer call: no stored node, discovery finds a server
+      ;(axios.get as jest.Mock).mockResolvedValue({
+        data: { region: 'eu', known_servers: ['a'], timestamp: 1000 }
+      })
+
+      const firstResult = await freshClient.getRelayServer()
+      expect(firstResult.timestamp).toBe(1000)
+
+      // Force the localTimestamp to be old so the stale-timestamp refresh path triggers
+      const relayServerPromise = (freshClient as any).relayServer
+      if (relayServerPromise) {
+        const resolved = await relayServerPromise.promise
+        resolved.localTimestamp = 0
+      }
+
+      // The refresh call to the cached server fails (ETIMEDOUT).
+      // The recovery path resets state and retries via findBestRegionAndGetServer(),
+      // which probes all servers. Set up the mock so the first call rejects,
+      // then all subsequent calls (discovery probes) succeed with a new timestamp.
+      ;(axios.get as jest.Mock)
+        .mockReset()
+        .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+        .mockResolvedValue({
+          data: { region: 'us', known_servers: ['b'], timestamp: 2000 }
+        })
+
+      const secondResult = await freshClient.getRelayServer()
+
+      expect(secondResult.timestamp).toBe(2000)
+      expect(mockStorage.delete).toHaveBeenCalledWith(StorageKey.MATRIX_SELECTED_NODE)
     })
   })
 

--- a/packages/beacon-transport-matrix/package.json
+++ b/packages/beacon-transport-matrix/package.json
@@ -37,5 +37,8 @@
     "@airgap/beacon-core": "4.8.0",
     "@airgap/beacon-utils": "4.8.0",
     "axios": "^1.8.4"
+  },
+  "devDependencies": {
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
+++ b/packages/beacon-transport-matrix/src/communication-client/P2PCommunicationClient.ts
@@ -218,58 +218,81 @@ export class P2PCommunicationClient extends CommunicationClient {
   }
 
   public async getRelayServer(): Promise<{ server: string; timestamp: number }> {
+    // Fast path: in-memory cached relay server that's still fresh
     if (this.relayServer) {
       const relayServer = await this.relayServer.promise
 
-      // We make sure the locally cached timestamp is not older than 1 minute, if it is, we refresh it
       if (Date.now() - relayServer.localTimestamp < 60 * 1000) {
         return { server: relayServer.server, timestamp: relayServer.timestamp }
       }
 
-      const info = await this.getBeaconInfo(relayServer.server)
+      try {
+        const info = await this.getBeaconInfo(relayServer.server)
+        this.relayServer.resolve({
+          server: relayServer.server,
+          timestamp: info.timestamp,
+          localTimestamp: new Date().getTime()
+        })
+        return { server: relayServer.server, timestamp: info.timestamp }
+      } catch (error) {
+        logger.log('getRelayServer', `cached server ${relayServer.server} is unreachable, resetting`)
+        await this.storage.delete(StorageKey.MATRIX_SELECTED_NODE).catch((e: unknown) => logger.log(e))
+        this.relayServer = undefined
+        this.selectedRegion = undefined
+        // Fall through to discovery below
+      }
+    }
+
+    // First caller creates the promise; concurrent callers will await it above
+    this.relayServer = new ExposedPromise()
+
+    try {
+      // Try the localStorage-cached node first
+      const node = await this.storage.get(StorageKey.MATRIX_SELECTED_NODE)
+      if (node && node.length > 0) {
+        try {
+          const info = await this.getBeaconInfo(node)
+          this.relayServer.resolve({
+            server: node,
+            timestamp: info.timestamp,
+            localTimestamp: new Date().getTime()
+          })
+          return { server: node, timestamp: info.timestamp }
+        } catch (error) {
+          logger.log('getRelayServer', `stored node ${node} is unreachable, falling through to discovery`)
+          await this.storage.delete(StorageKey.MATRIX_SELECTED_NODE).catch((e: unknown) => logger.log(e))
+        }
+      }
+
+      // Full discovery: probe all servers, pick the fastest
+      const server = await this.findBestRegionAndGetServer()
+
+      if (!server) {
+        throw new Error('No servers found')
+      }
+
+      this.storage
+        .set(StorageKey.MATRIX_SELECTED_NODE, server.server)
+        .catch((error) => logger.log(error))
+
       this.relayServer.resolve({
-        server: relayServer.server,
-        timestamp: info.timestamp,
+        server: server.server,
+        timestamp: server.timestamp,
         localTimestamp: new Date().getTime()
       })
-      return { server: relayServer.server, timestamp: info.timestamp }
-    } else {
-      this.relayServer = new ExposedPromise()
+
+      return { server: server.server, timestamp: server.timestamp }
+    } catch (error) {
+      // Always settle the ExposedPromise so concurrent callers don't hang forever
+      this.relayServer.reject(error)
+      this.relayServer = undefined
+      throw error
     }
-
-    const node = await this.storage.get(StorageKey.MATRIX_SELECTED_NODE)
-    if (node && node.length > 0) {
-      const info = await this.getBeaconInfo(node)
-      this.relayServer.resolve({
-        server: node,
-        timestamp: info.timestamp,
-        localTimestamp: new Date().getTime()
-      })
-      return { server: node, timestamp: info.timestamp }
-    }
-
-    const server = await this.findBestRegionAndGetServer()
-
-    if (!server) {
-      throw new Error(`No servers found`)
-    }
-
-    this.storage
-      .set(StorageKey.MATRIX_SELECTED_NODE, server.server)
-      .catch((error) => logger.log(error))
-
-    this.relayServer.resolve({
-      server: server.server,
-      timestamp: server.timestamp,
-      localTimestamp: new Date().getTime()
-    })
-
-    return { server: server.server, timestamp: server.timestamp }
   }
 
   public async getBeaconInfo(server: string): Promise<BeaconInfoResponse> {
     return axios
-      .get<BeaconInfoResponse>(`https://${server}/_synapse/client/beacon/info`)
+      .get<BeaconInfoResponse>(`https://${server}/_synapse/client/beacon/info`, { timeout: 10_000 })
       .then((res) => ({
         region: res.data.region,
         known_servers: res.data.known_servers,


### PR DESCRIPTION
## Summary

- **getRelayServer() deadlocks when a stored relay node dies.** The `ExposedPromise` is never settled, hanging every concurrent caller forever. Users get permanently stuck on page reload with no way to recover except manually clearing site data.

- Add **10s timeout** to `getBeaconInfo()` so dead nodes fail fast instead of hanging indefinitely.

- **Wrap all `getBeaconInfo()` calls** in `getRelayServer()` with try/catch. On failure, delete the stale node from storage and fall through to server discovery via `findBestRegionAndGetServer()`.

- **Guarantee `ExposedPromise` settlement** on every code path. The outer try/catch rejects and clears the promise on any error, so concurrent callers get a proper rejection instead of hanging.

## Test plan

- [x] New tests: dead node falls through to discovery
- [x] New tests: healthy stored node still works (no regression)
- [x] New tests: ExposedPromise is rejected and cleared when all servers fail
- [x] New tests: cached server timeout triggers reset and rediscovery
- [x] Updated `getBeaconInfo` test to verify 10s timeout option